### PR TITLE
chore: upgrade to polkadot v1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1664,7 +1664,7 @@ dependencies = [
  "sc-service",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "url",
 ]
 
@@ -1685,10 +1685,10 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "tracing",
 ]
 
@@ -1719,17 +1719,17 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "schnellru",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
- "sp-inherents 31.0.0",
+ "sp-inherents",
  "sp-keystore",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -1758,9 +1758,9 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-timestamp",
- "sp-trie 34.0.0",
+ "sp-trie",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -1775,9 +1775,9 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -1800,8 +1800,8 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "tracing",
 ]
 
@@ -1819,14 +1819,14 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-crypto-hashing",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
  "sp-storage",
- "sp-trie 34.0.0",
+ "sp-trie",
  "tracing",
 ]
 
@@ -1851,7 +1851,7 @@ dependencies = [
  "sc-consensus",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "tracing",
 ]
 
@@ -1884,12 +1884,12 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-transaction-pool",
 ]
 
@@ -1900,15 +1900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa2703d49952e0538c4d05fe1f1114e62741871693e862fc68ab56ae6b3b5230"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -1924,9 +1924,9 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
@@ -1937,15 +1937,15 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-externalities",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
- "sp-version 34.0.0",
+ "sp-trie",
+ "sp-version",
  "staging-xcm",
- "trie-db 0.29.1",
+ "trie-db",
 ]
 
 [[package]]
@@ -1966,12 +1966,12 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be9d77e00ad1dbcf12dcd81c2758d651adf6e3072f3cb51c11d8739426f4cbb"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -1982,12 +1982,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b7737eb5d81bcd79df114e711927ba19c2dbd312f245ae03b76d330abb3506d"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "staging-xcm",
 ]
@@ -2001,9 +2001,9 @@ dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
@@ -2011,8 +2011,8 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
@@ -2027,9 +2027,9 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-primitives",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus-aura",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2044,10 +2044,10 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "scale-info",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
- "sp-trie 34.0.0",
+ "sp-trie",
  "staging-xcm",
 ]
 
@@ -2062,11 +2062,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -2077,7 +2077,7 @@ checksum = "e736734a6b4b0308d931756c30c3472fa5ec99a95be14f70567f25c97b3822cc"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
- "sp-trie 34.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -2089,12 +2089,12 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2105,14 +2105,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee70eb2f55d20a965e3538fc96aac2801815af510b4460e8a5783f5197e0872"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 33.0.0",
+ "frame-support",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -2137,11 +2137,11 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -2157,9 +2157,9 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -2196,11 +2196,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2231,14 +2231,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
- "sp-version 34.0.0",
+ "sp-version",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2255,10 +2255,10 @@ dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -3147,50 +3147,24 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6f8e21cbac73688175cf9b531ed1c3f6578420a0f6106282aa8e5ed6fe3347"
-dependencies = [
- "frame-support 32.0.0",
- "frame-support-procedural 27.0.0",
- "frame-system 32.0.0",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api 30.0.0",
- "sp-application-crypto 34.0.0",
- "sp-core",
- "sp-io 34.0.0",
- "sp-runtime 35.0.0",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-benchmarking"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f963589fa0f5ef5fe87fad5a9ac9ec4a43d83fd63e1993024576a8dcaee5e228"
 dependencies = [
- "frame-support 33.0.0",
- "frame-support-procedural 28.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-support-procedural",
+ "frame-system",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
@@ -3208,9 +3182,9 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "gethostname",
  "handlebars",
  "itertools 0.10.5",
@@ -3230,19 +3204,19 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
- "sp-trie 34.0.0",
+ "sp-trie",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -3267,14 +3241,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6e46fd5f6bbbce22fcb19bccce899b4e83e917ba5181b1adae94abb086f124"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -3285,15 +3259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01d5b1ec42b019aa16d1f9269f74f391c32ce642cb2aad7b1b6a6d65a34e1bc6"
 dependencies = [
  "aquamarine 0.3.3",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-tracing",
 ]
@@ -3318,54 +3292,12 @@ checksum = "c51ead97e4ac8fdd3b62258bf5f97d2d82412ec0386388ce8296aa23d561536f"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
-]
-
-[[package]]
-name = "frame-support"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97100a956a2cd152ad4e63a5ec7b5e58503653223a73fff6e916b910b37f12ed"
-dependencies = [
- "aquamarine 0.5.0",
- "array-bytes 6.2.3",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata",
- "frame-support-procedural 27.0.0",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "smallvec",
- "sp-api 30.0.0",
- "sp-arithmetic",
- "sp-core",
- "sp-crypto-hashing-proc-macro",
- "sp-debug-derive",
- "sp-genesis-builder 0.11.0",
- "sp-inherents 30.0.0",
- "sp-io 34.0.0",
- "sp-metadata-ir",
- "sp-runtime 35.0.0",
- "sp-staking 30.0.0",
- "sp-state-machine 0.39.0",
- "sp-std",
- "sp-tracing",
- "sp-weights",
- "static_assertions",
- "tt-call",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3380,7 +3312,7 @@ dependencies = [
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural 28.0.0",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -3391,43 +3323,23 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-metadata-ir",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-staking",
+ "sp-state-machine",
  "sp-std",
  "sp-tracing",
  "sp-weights",
  "static_assertions",
  "tt-call",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a74eda80052082e8acd36c7fa232569ce1f968c7ae2adc56d082039ac9d6ba4"
-dependencies = [
- "Inflector",
- "cfg-expr",
- "derive-syn-parse 0.2.0",
- "expander 2.1.0",
- "frame-support-procedural-tools 11.0.1",
- "itertools 0.10.5",
- "macro_magic",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "sp-crypto-hashing",
- "syn 2.0.65",
 ]
 
 [[package]]
@@ -3440,26 +3352,13 @@ dependencies = [
  "cfg-expr",
  "derive-syn-parse 0.2.0",
  "expander 2.1.0",
- "frame-support-procedural-tools 12.0.0",
+ "frame-support-procedural-tools",
  "itertools 0.10.5",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.65",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b482a1d18fa63aed1ff3fe3fcfb3bc23d92cb3903d6b9774f75dc2c4e1001c3a"
-dependencies = [
- "frame-support-procedural-tools-derive",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
  "syn 2.0.65",
 ]
 
@@ -3489,43 +3388,22 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562e02f5139f1beb0edd3cac2db3f974d98b7459342210d101f451d26886ca33"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support 32.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io 34.0.0",
- "sp-runtime 35.0.0",
- "sp-std",
- "sp-version 33.0.0",
- "sp-weights",
-]
-
-[[package]]
-name = "frame-system"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64265317899a2ecfc465a1ab55fa3094dbbbc7061292592fdbbb8acc136c4735"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 33.0.0",
+ "frame-support",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "sp-version 34.0.0",
+ "sp-version",
  "sp-weights",
 ]
 
@@ -3535,13 +3413,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a23446bf524bcc64351ecc5a50925debdc92d50a0b8384c3064dc13b3c64ca3"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -3552,7 +3430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54771ae481dd08825d4de28b1b3623163efd9e7c4b59a6db1fb048dcdf73789e"
 dependencies = [
  "parity-scale-codec",
- "sp-api 31.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -3561,10 +3439,10 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f542a58bd43234882faff12062ce94838b3bbca1b6ed6b32180ee153350905f"
 dependencies = [
- "frame-support 33.0.0",
+ "frame-support",
  "parity-scale-codec",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -5580,13 +5458,13 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5598,11 +5476,11 @@ dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6220,17 +6098,17 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00878f866191e08a7f6a74a0378c1d4d759e356d5fc3e3dae51fa414b44fad93"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6240,13 +6118,13 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2908c5abe694fc6d1e9f1dbc9049910cf7086416e0c3214ff4734f02c055d82"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6256,33 +6134,16 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdecfbbcc55a4050a91bf2180b5b574fe3e20a925c1a836187041974c6f9248"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-assets"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda0d9362dc1b75cead58f5e9a6004d305f81b2bf38c52e5454d1d868e2cc98f"
-dependencies = [
- "frame-benchmarking 32.0.0",
- "frame-support 32.0.0",
- "frame-system 32.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-runtime 35.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6292,14 +6153,14 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14bb2544de653caa76f88156c53ccdea218737ae00ef37b949786bc4c13719f8"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6309,15 +6170,15 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d39e0cf359277a802199f4f78604ddb62f6616e6c625a3b958abec063b1a66f"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6327,14 +6188,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35807c44d2caf67038ae3b3cd948a36014a63e75f96bab3754350deec7cf8e20"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-authority-discovery",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6344,12 +6205,12 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c6fadb06cb9f04998aebabf282e15a6bc35ac36de0c6fccb43a0efb38a755c"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6359,22 +6220,22 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1e8bc4e03c6e92cfbac89e9b505ff43fae538915fc277f4597733775c49fa76"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6386,17 +6247,17 @@ checksum = "235a798b0ef83ef012fe79ed01617d84882e682aa40b937ca22e23ee429ab2d7"
 dependencies = [
  "aquamarine 0.5.0",
  "docify",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-tracing",
 ]
@@ -6408,13 +6269,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c00a7041511735547ac443a14ecb2915976725dfbf1d3d9f64df20359e483e"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6424,8 +6285,8 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a846fddc17ec4bb5901f446a1f474090de2778c215aea9ab209631c88cf879"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6433,9 +6294,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6447,8 +6308,8 @@ checksum = "b59f46e15d62db39a20fb254324f5a33cf3c652ca6aa656ba6419ae5c8059336"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -6456,12 +6317,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus-beefy",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
 ]
 
@@ -6471,16 +6332,16 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56765a826bcdc19693fc327757108d79ac03e7545bc3561a2434bb0238679ee6"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6491,16 +6352,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e06a681df643f0bf7225c09b4d33ceaaebfe6ebfb13d0ea686f11d20901e9b"
 dependencies = [
  "bitvec",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6510,17 +6371,17 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "813290bcfde2e10ad4a37763642e22186e28cf7d675cbf525f2276151444008c"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6530,9 +6391,9 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b8c0293db4d8d6632330e8ea1d8ad83711c144fe8b03a14ae15fe1678c7291b"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-balances",
@@ -6540,8 +6401,8 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6551,15 +6412,15 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f5bea608ae6d9e8e12cd1e57d4781ccccf62a87e498bb6318ffe2243815ab4"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6570,14 +6431,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b8fc61dec0ae9760f00fb84a621e383ebb0bd1d2f6a4777bc55977624da5d1"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6587,16 +6448,16 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb285cd2c58b49219c9980b9c30d4c241920c5a55ae5df44c6e3649dd5057fd"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6606,10 +6467,10 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45d7050267a6ce48b2d5530ea5c3b939c8f8a70e42b26db96cb1e859a3dd40c9"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
@@ -6617,9 +6478,9 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
  "strum 0.26.2",
 ]
@@ -6630,12 +6491,12 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cea3c30507dd5bc3ca2657a2b729dbb9c77f0ae7103778e148d4667d1f0dfe6"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-system 33.0.0",
+ "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6645,17 +6506,17 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4482e691c61ea7d68d09a0d3221a2223b36118874c1923a3733a0ff1a9d4a65"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6666,16 +6527,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3413d41515d5679fa680f96ceac185ede18ac22002837216c9fab863d4a367b7"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6685,21 +6546,21 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63024f2e3aee907a345db4993982b0a853cc330e487d0b7aa2b63bf956bb2a04"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6710,14 +6571,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b59201c3a7fad2acc3623e0e933359588e86ba6445ec4e2ced9a56cbc150658"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6727,18 +6588,18 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "859266edee477b8d7c8f07bbe48956f2d0093b7a7466b473df66e6de4dd59445"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6748,15 +6609,15 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81babd3f9b3af66f27f7af6dfdea1943d16598630c5f4eda34ec56bdb7185dbd"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-keyring",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6766,15 +6627,15 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d72c43d36e246e388b911ce85176962eeaf7893acb472fe1c4377c7007f886d"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6785,16 +6646,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cf3baf644a42f0520f030e91e24c72e3d6691f7abc347345219b2e744fc835"
 dependencies = [
  "environmental",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
 ]
@@ -6805,16 +6666,16 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f6cdaa2b8423f910e260b93065b8c63c7ebbc21c288419bc7a9aa0ed7a14fa"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6824,63 +6685,63 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4957a1571ca0a761520942623d7d1ff71f2831edfc2f2fc43ad454682e50ad95"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nft-fractionalization"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677e05e538410a056620e737a4b9c9073a2636fcaab99609a57d0c706af4b186"
+checksum = "3725969acea961bbd0fe469d3de423897b48d177dfb1251138e44a23056f8f90"
 dependencies = [
- "frame-benchmarking 32.0.0",
- "frame-support 32.0.0",
- "frame-system 32.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-assets 33.0.0",
+ "pallet-assets",
  "pallet-nfts",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 35.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nfts"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190767bc88a1a23f51fccc445a271639fd5a88f1811291d801221e5b9b5b48cc"
+checksum = "24460dcc55227dd89c8e1336a9d9bffed6dcfc8d11207922a02705d5a7bc6d15"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 32.0.0",
- "frame-support 32.0.0",
- "frame-system 32.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 34.0.0",
- "sp-runtime 35.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nfts-runtime-api"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b086ef37b5a2ab6d9c67929bd26480dfc128023039f238f6bc2b25a7348c1232"
+checksum = "f9ebe8124be6f8e4821cb53cd90d3b40c25bd6cb3bc9ca00fe7351f3c02755f9"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
- "sp-api 30.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -6890,14 +6751,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9317c665f1692637b3ede02fef4153ae3c4a4fb4b196bbea07a6a011546ab74"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6907,16 +6768,16 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1edc38d7ba687163bdf2562b1fd8d440d63648c193b6c9e899ea12a607747ed"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
  "sp-tracing",
 ]
@@ -6927,18 +6788,18 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd63c332aa3c111d10268c29aa439180d4b94c8adecbf526f0a04aeea46bea1"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-bags-list",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6950,7 +6811,7 @@ checksum = "e3980bcda50ec619f93dbb8b73f824413ee5dccabe3511fca4454c49857c1483"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -6960,15 +6821,15 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d02ba6a9a9c27685404f979534ab254f0cda028857ebdb19f7cb9aa0f52bc6b"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6978,10 +6839,10 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de8b5190c4421f6550504bd1753f82492c28cda5b1ccb6c2759494cdfa431207"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-babe",
  "pallet-balances",
@@ -6992,8 +6853,8 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -7004,15 +6865,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8bc500ff1d3292950a7d1b50b0e26f7cd9f886cd4a577883267d36a1da1361"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7022,15 +6883,15 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20718f6531ad2adf84ed0b1f845f29e29987b7fd1ccb738134c60e77177f1d0"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7040,13 +6901,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a73160cf5aa5ebf1f07eb1134328b272ab16070028c8c1ee9f800ffa3a5c03db"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7056,17 +6917,17 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "082ef6517f3901106bc642a7bb35b9c8345cbe55c5c60dbf6b09081b2e3c5695"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7076,13 +6937,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06afe44a0484ad3c8b943c555fe4d7ccc9da3b3cd1093ddb6a8984bae6f130f4"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7093,16 +6954,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b6c4f5bc65be570a065907239d3215036d3e29edbd0ea5c6cd01246e2ba3959"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7112,13 +6973,13 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e4b63ec79ab485d54cf79fd5ef574bb7f8f4e094e4a7d11b012a820d4324b62"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7129,14 +6990,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7570e307118a4663dd3a1d1c949f84a169ef932666e69f7fcf4357781c8c1a4e"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
 ]
@@ -7147,21 +7008,21 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925f793adb1d53c05233ffd2644ca37890d56c9716475108b975969a445d10b3"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
- "sp-state-machine 0.40.0",
+ "sp-staking",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -7170,14 +7031,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca61297e13c15fef1e4d3b7f2884e70c772be3a9448977ba23954e2c4bcea4bd"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-std",
 ]
@@ -7188,16 +7049,16 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8584534df25227dd43d80803ea1978af55bf70aad5aa57c83dc3de883b1f1c73"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "scale-info",
  "sp-arithmetic",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7207,10 +7068,10 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f68e48f3d79e0cbb9462eacc0c85c80003924124a893465047f159278338036d"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -7218,10 +7079,10 @@ dependencies = [
  "rand_chacha 0.2.2",
  "scale-info",
  "serde",
- "sp-application-crypto 35.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -7254,8 +7115,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c431ab74db8258b39fe829fb7345d38064ef7fb1ce2014b074f586303d7dee67"
 dependencies = [
  "parity-scale-codec",
- "sp-api 31.0.0",
- "sp-staking 31.0.0",
+ "sp-api",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7264,15 +7125,15 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9db0ce6ccf9e1d2fe2d0b26cecce995e4b095b31bbf9f0492024fbfd4924961a"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7283,13 +7144,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10ee43e8bb38a50a234ef49198413483562e229ca20d8e9d9f78b756244f6d7c"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7300,15 +7161,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5982a7cc371e2b9be504465bb6e47bc27dba0b98ee9794d7fc797c24244fb6d9"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-storage",
  "sp-timestamp",
@@ -7320,17 +7181,17 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e0d02dcd034cb57cb25f1301c6e6c43b8191b96b049e7d013564aaf5d3c6af"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7340,14 +7201,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aad5b92a96c4e38c7917477a1e5f2916c64f667f2734b2bf790ce552ceada82c"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7360,11 +7221,11 @@ dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7376,8 +7237,8 @@ checksum = "f274055d2c61888689889d6e9b9266b163e1ed298967b55bf961db26b11a60fe"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7388,16 +7249,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23a11166748c80a432c52d5cc99c2b0e1d2b88592e0ad71eec7cb9f360e375c7"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7407,14 +7268,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1c70a4abf287304214b16d9eb88f13c991bd696f9e5318fc68e74df9802037"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7424,13 +7285,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a5b229675f299af7aa40749c579570dce4ab19739779a45f5a87da118af8ef"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7440,13 +7301,13 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "249172db9f2b014a6e9d4b5c6d663bcbcb0055c1c2c7564e7bd0488ecb1f15b8"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7457,17 +7318,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9e654cf90682370fe20a04904cb02df993c3b0dcfad861abcf2811f4fa6085"
 dependencies = [
  "bounded-collections",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -7481,14 +7342,14 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b7038af027fcce5ba3d2f99b941fb997a5556f1fa0b8a7e7e23a448be1bb85"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -7510,7 +7371,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures",
  "jsonrpsee",
@@ -7538,14 +7399,14 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-aura",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-timestamp",
  "staging-xcm",
  "substrate-build-script-utils",
@@ -7567,17 +7428,17 @@ dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-utility",
  "docify",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex-literal",
  "log",
- "pallet-assets 33.0.0",
+ "pallet-assets",
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
@@ -7598,18 +7459,18 @@ dependencies = [
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
- "sp-version 34.0.0",
+ "sp-version",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-builder",
@@ -7625,11 +7486,11 @@ checksum = "43acd23527a3471b1c596b809591edf78d6113bba172fff4a96412d560dfea59"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-asset-tx-payment",
- "pallet-assets 34.0.0",
+ "pallet-assets",
  "pallet-authorship",
  "pallet-balances",
  "pallet-collator-selection",
@@ -7640,8 +7501,8 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "staging-parachain-info",
  "staging-xcm",
@@ -8063,10 +7924,10 @@ dependencies = [
  "sc-sysinfo",
  "sc-tracing",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-build-script-utils",
  "thiserror",
 ]
@@ -8088,7 +7949,7 @@ dependencies = [
  "polkadot-primitives",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
  "tokio-util",
  "tracing-gum",
@@ -8103,7 +7964,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -8127,7 +7988,7 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-keystore",
  "thiserror",
  "tracing-gum",
@@ -8144,7 +8005,7 @@ dependencies = [
  "polkadot-primitives",
  "reed-solomon-novelpoly",
  "sp-core",
- "sp-trie 34.0.0",
+ "sp-trie",
  "thiserror",
 ]
 
@@ -8164,7 +8025,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
@@ -8240,10 +8101,10 @@ dependencies = [
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
  "tracing-gum",
 ]
@@ -8396,7 +8257,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents 31.0.0",
+ "sp-inherents",
  "thiserror",
  "tracing-gum",
 ]
@@ -8506,7 +8367,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-tracing",
  "thiserror",
  "tracing-gum",
@@ -8589,7 +8450,7 @@ dependencies = [
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "strum 0.26.2",
  "thiserror",
  "tracing-gum",
@@ -8609,12 +8470,12 @@ dependencies = [
  "polkadot-primitives",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
  "sp-maybe-compressed-blob",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
  "zstd 0.12.4",
 ]
@@ -8651,11 +8512,11 @@ dependencies = [
  "sc-network-types",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -8689,7 +8550,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -8713,7 +8574,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "tikv-jemalloc-ctl",
  "tracing-gum",
@@ -8732,7 +8593,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
 ]
@@ -8751,17 +8612,17 @@ dependencies = [
  "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -8788,13 +8649,13 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -8806,10 +8667,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3effc5cafb231ede1c394abce9575c292e95170e11ee1ecc5644d25cf35b54b9"
 dependencies = [
  "bitvec",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
@@ -8836,14 +8697,14 @@ dependencies = [
  "serde",
  "serde_derive",
  "slot-range-helper",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -8858,7 +8719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cfaa021e4639e9fcba7c40111d93720b82cea98d667889760e46a40137e3d47"
 dependencies = [
  "bs58 0.5.1",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-std",
@@ -8874,9 +8735,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
@@ -8899,16 +8760,16 @@ dependencies = [
  "rustc-hex",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
@@ -8923,10 +8784,10 @@ checksum = "fc6acbf05debbbab4831318fdbe0619742573dda47721af7e2ff042def2ec77a"
 dependencies = [
  "async-trait",
  "bitvec",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex-literal",
@@ -9005,7 +8866,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -9014,19 +8875,19 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
- "sp-version 34.0.0",
+ "sp-version",
  "sp-weights",
  "staging-xcm",
  "substrate-prometheus-endpoint",
@@ -9055,7 +8916,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sp-keystore",
- "sp-staking 31.0.0",
+ "sp-staking",
  "thiserror",
  "tracing-gum",
 ]
@@ -9973,10 +9834,10 @@ checksum = "224e7b002c0ba04bcee4bf25e2d90ff1895a9c1171fd8c3162c63a558c33a0d4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-executive",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -10038,7 +9899,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
@@ -10046,18 +9907,18 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 34.0.0",
+ "sp-version",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -10072,12 +9933,12 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578bde81aeca421df7d898726f0d3d9caea11eed87d77760be71177ce071977f"
 dependencies = [
- "frame-support 33.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-weights",
  "staging-xcm",
  "staging-xcm-builder",
@@ -10397,12 +10258,12 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-types",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10421,12 +10282,12 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10437,13 +10298,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4190e69ccdf1b10c530e110345d67c6347aa0bc03fa56723103d834fb8ac907d"
 dependencies = [
  "parity-scale-codec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-trie 34.0.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10467,10 +10328,10 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-genesis-builder 0.12.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-genesis-builder",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-tracing",
 ]
 
@@ -10522,8 +10383,8 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-panic-handler",
- "sp-runtime 36.0.0",
- "sp-version 34.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
  "tokio",
 ]
@@ -10542,17 +10403,17 @@ dependencies = [
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-statement-store",
  "sp-storage",
- "sp-trie 34.0.0",
+ "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10578,9 +10439,9 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-database",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
- "sp-trie 34.0.0",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10599,12 +10460,12 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10624,17 +10485,17 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 31.0.0",
+ "sp-inherents",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10660,8 +10521,8 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
@@ -10669,9 +10530,9 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-crypto-hashing",
- "sp-inherents 31.0.0",
+ "sp-inherents",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10688,14 +10549,14 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10720,8 +10581,8 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "sc-utils",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10730,7 +10591,7 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10753,7 +10614,7 @@ dependencies = [
  "serde",
  "sp-consensus-beefy",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10768,7 +10629,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10802,8 +10663,8 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10811,7 +10672,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10833,7 +10694,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10856,9 +10717,9 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -10873,14 +10734,14 @@ dependencies = [
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "sp-externalities",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-panic-handler",
  "sp-runtime-interface",
- "sp-trie 34.0.0",
- "sp-version 34.0.0",
+ "sp-trie",
+ "sp-version",
  "sp-wasm-interface",
  "tracing",
 ]
@@ -10945,7 +10806,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10957,7 +10818,7 @@ dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.2",
  "serde_json",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -10984,12 +10845,12 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
  "sp-keystore",
  "sp-mixnet",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11034,7 +10895,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11061,7 +10922,7 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11080,7 +10941,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -11103,7 +10964,7 @@ dependencies = [
  "sc-network-types",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11138,7 +10999,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11162,7 +11023,7 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -11207,12 +11068,12 @@ dependencies = [
  "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "threadpool",
  "tracing",
 ]
@@ -11247,16 +11108,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-statement-store",
- "sp-version 34.0.0",
+ "sp-version",
  "tokio",
 ]
 
@@ -11276,8 +11137,8 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-rpc",
- "sp-runtime 36.0.0",
- "sp-version 34.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
 ]
 
@@ -11322,12 +11183,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime 36.0.0",
- "sp-version 34.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -11375,20 +11236,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie 34.0.0",
- "sp-version 34.0.0",
+ "sp-trie",
+ "sp-version",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -11440,7 +11301,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11462,7 +11323,7 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-std",
 ]
 
@@ -11506,11 +11367,11 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-tracing",
  "thiserror",
  "tracing",
@@ -11547,11 +11408,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -11571,7 +11432,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -12072,7 +11933,7 @@ dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -12260,29 +12121,6 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8abd1d0732054ad896db8f092abe822106f1acf8bbc462c70f57d0f24c0dcdf"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro 18.0.0",
- "sp-core",
- "sp-externalities",
- "sp-metadata-ir",
- "sp-runtime 35.0.0",
- "sp-runtime-interface",
- "sp-state-machine 0.39.0",
- "sp-std",
- "sp-trie 33.0.0",
- "sp-version 33.0.0",
- "thiserror",
-]
-
-[[package]]
-name = "sp-api"
 version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b500647cfe266d58781f44af9b13c3bd57fb3be08642f2a9f13e024cc5e22359"
@@ -12291,32 +12129,17 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 19.0.0",
+ "sp-api-proc-macro",
  "sp-core",
  "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
- "sp-version 34.0.0",
+ "sp-trie",
+ "sp-version",
  "thiserror",
-]
-
-[[package]]
-name = "sp-api-proc-macro"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681e80c1b259ee71880cd3b4ad2a2d41454596252bd267c3edf4e14552ab40e1"
-dependencies = [
- "Inflector",
- "blake2 0.10.6",
- "expander 2.1.0",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.65",
 ]
 
 [[package]]
@@ -12336,20 +12159,6 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505fad69251900048ddddc6387265e1545d1a366e3b4dcd57b76a03f0a65ae7"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io 34.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "sp-application-crypto"
 version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57541120624a76379cc993cbb85064a5148957a92da032567e54bce7977f51fc"
@@ -12358,7 +12167,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-std",
 ]
 
@@ -12386,9 +12195,9 @@ checksum = "6d8494eafd70194198b7fd82446da59380c7346bedf68e83dfbdb5f338395437"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12397,9 +12206,9 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51cf3d8fb96de98aecdd32cdd4a735af4d84fae274314f411f95c89d4dff6ad3"
 dependencies = [
- "sp-api 31.0.0",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12413,11 +12222,11 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.2",
  "schnellru",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-database",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -12431,9 +12240,9 @@ dependencies = [
  "futures",
  "log",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -12446,11 +12255,11 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -12464,12 +12273,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -12483,14 +12292,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "strum 0.26.2",
 ]
 
@@ -12505,11 +12314,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12630,17 +12439,6 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8a812b56fb4ed6a598ad7b43be127702aba1f7351ad4916f5bab995054cdc5"
-dependencies = [
- "serde_json",
- "sp-api 30.0.0",
- "sp-runtime 35.0.0",
-]
-
-[[package]]
-name = "sp-genesis-builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7605a8ed2c06d348c26055b7907c3d2d62f984666e9025b57df4895f865f5901"
@@ -12648,22 +12446,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcba3b816fdfadf30d8c7c484e1873f1af89ed2560c77d2b2137d152cc5a585"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 35.0.0",
- "thiserror",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12676,35 +12460,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
-]
-
-[[package]]
-name = "sp-io"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c44ed47247b6eee76ff703f9fa9f04f99c4104ac1faf629e6d1128e09066b57b"
-dependencies = [
- "bytes",
- "ed25519-dalek 2.1.1",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive",
- "rustversion",
- "secp256k1",
- "sp-core",
- "sp-crypto-hashing",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine 0.39.0",
- "sp-std",
- "sp-tracing",
- "sp-trie 33.0.0",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -12726,10 +12483,10 @@ dependencies = [
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "sp-std",
  "sp-tracing",
- "sp-trie 34.0.0",
+ "sp-trie",
  "tracing",
  "tracing-core",
 ]
@@ -12741,7 +12498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d2c495248bd141fe04ec639785c874949b2c552c00ea4afc4c183c654466ce"
 dependencies = [
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "strum 0.26.2",
 ]
 
@@ -12786,8 +12543,8 @@ checksum = "2242e7a802822109e007c3d6ee79640f8dc3abee7139d34ce029c7478361be8c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
 ]
 
 [[package]]
@@ -12801,10 +12558,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "sp-debug-derive",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -12819,7 +12576,7 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12828,9 +12585,9 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cbbd2096fda34c2f6f9f268c808ca280c08565e759309ea24f17dcd0808097b"
 dependencies = [
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12857,31 +12614,6 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ce931b7fbfdeeca1340801dbd4a1cae54ad4c97a1e3dcfcc79709bc800dd46"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 34.0.0",
- "sp-arithmetic",
- "sp-core",
- "sp-io 34.0.0",
- "sp-std",
- "sp-weights",
-]
-
-[[package]]
-name = "sp-runtime"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6b85cb874b78ebb17307a910fc27edf259a0455ac5155d87eaed8754c037e07"
@@ -12897,10 +12629,10 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-std",
  "sp-weights",
 ]
@@ -12947,25 +12679,11 @@ checksum = "9c558f85486882433adcfdfe05c5e82972a7be1a6d7fa68a6213b70ec1d86068"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
-]
-
-[[package]]
-name = "sp-staking"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43ec7f6c9759ba3011a16bb022afe056bc26f88b3c424598737cba71d3ef0"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime 35.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -12979,28 +12697,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d9078306c3066f1824e41153e1ceec34231d39d9a7e7956b101eadf7b9fd3a"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.2",
- "rand 0.8.5",
- "smallvec",
- "sp-core",
- "sp-externalities",
- "sp-panic-handler",
- "sp-trie 33.0.0",
- "thiserror",
- "tracing",
- "trie-db 0.28.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13018,10 +12715,10 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-trie 34.0.0",
+ "sp-trie",
  "thiserror",
  "tracing",
- "trie-db 0.29.1",
+ "trie-db",
 ]
 
 [[package]]
@@ -13038,12 +12735,12 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
  "thiserror",
  "x25519-dalek 2.0.1",
@@ -13076,8 +12773,8 @@ checksum = "bdb7768c895643e315f9bcfacdd61e283b78c862d976fd081a508cf7239c8643"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -13099,8 +12796,8 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "207cb372504cf86237fa63953a0aa40d7596d1c9cf21175a56346ed1744eb8fe"
 dependencies = [
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13113,33 +12810,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-trie 34.0.0",
-]
-
-[[package]]
-name = "sp-trie"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f5b3620a1c87c265a83d85d7519c6b60c47acf7f77593966afe313d086f00e"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot 0.12.2",
- "rand 0.8.5",
- "scale-info",
- "schnellru",
- "sp-core",
- "sp-externalities",
- "thiserror",
- "tracing",
- "trie-db 0.28.0",
- "trie-root",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -13162,26 +12835,8 @@ dependencies = [
  "sp-externalities",
  "thiserror",
  "tracing",
- "trie-db 0.29.1",
+ "trie-db",
  "trie-root",
-]
-
-[[package]]
-name = "sp-version"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba2f18b89ac5f356fb247f70163098bc976117221c373d5590079a5797a3b43"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro",
- "sp-runtime 35.0.0",
- "sp-std",
- "sp-version-proc-macro",
- "thiserror",
 ]
 
 [[package]]
@@ -13196,7 +12851,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -13301,11 +12956,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4efd2f6285b97c1797f8451afb9834a90bd7b90712e6d1a3df8f68f9e7357ea6"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -13334,8 +12989,8 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ccd51b148ec7c72f98cd315952595af353c103f4ad76cb600a85b8ee60adf4"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-transaction-payment",
@@ -13343,8 +12998,8 @@ dependencies = [
  "polkadot-parachain-primitives",
  "scale-info",
  "sp-arithmetic",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
  "staging-xcm",
@@ -13358,16 +13013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39025611744d726ee1cb6661c09b13cd41525ca791f4fba45d68a00db9582063"
 dependencies = [
  "environmental",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
  "staging-xcm",
@@ -13519,11 +13174,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13551,10 +13206,10 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
- "sp-trie 34.0.0",
- "trie-db 0.29.1",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
+ "trie-db",
 ]
 
 [[package]]
@@ -13575,10 +13230,10 @@ dependencies = [
  "polkavm-linker",
  "sc-executor",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-maybe-compressed-blob",
  "sp-tracing",
- "sp-version 34.0.0",
+ "sp-version",
  "strum 0.26.2",
  "tempfile",
  "toml 0.8.13",
@@ -14203,19 +13858,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
-]
-
-[[package]]
-name = "trie-db"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
-dependencies = [
- "hash-db",
- "hashbrown 0.13.2",
- "log",
- "rustc-hex",
- "smallvec",
 ]
 
 [[package]]
@@ -14996,11 +14638,11 @@ checksum = "13acc56783ce7fca15017890034ed043cb91de2caab28a91a5b4209a1214eed4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -15066,27 +14708,27 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-core",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 34.0.0",
+ "sp-version",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -15101,12 +14743,12 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eb9a91bc8d5ec0a260735651284eb4420c1a2de62b2430cf16c723186eabd28"
 dependencies = [
- "frame-support 33.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-weights",
  "staging-xcm",
  "staging-xcm-builder",
@@ -15520,11 +15162,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92be74937c8012c951c667bb0fb016634ab4adeac46f8106aef331f836059167"
 dependencies = [
- "frame-support 33.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
  "staging-xcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -97,18 +97,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "always-assert"
@@ -142,47 +142,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -190,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "approx"
@@ -228,7 +229,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -357,7 +358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -368,9 +369,9 @@ checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
 
 [[package]]
 name = "array-bytes"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f840fb7195bcfc5e17ea40c26e5ce6d5b9ce5d584466e17703209657e459ae0"
+checksum = "5d5dde061bd34119e902bbb2d9b90c5692635cf59fb91d582c2b68043f1b8293"
 
 [[package]]
 name = "arrayref"
@@ -451,28 +452,26 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.2.0",
- "event-listener-strategy 0.5.0",
+ "event-listener-strategy 0.5.2",
  "futures-core",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.8.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
 dependencies = [
- "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
- "fastrand 2.0.1",
- "futures-lite 2.2.0",
+ "fastrand 2.1.0",
+ "futures-lite 2.3.0",
  "slab",
 ]
 
@@ -518,10 +517,10 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.2.0",
+ "futures-lite 2.3.0",
  "parking",
- "polling 3.5.0",
- "rustix 0.38.31",
+ "polling 3.7.0",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -544,7 +543,7 @@ checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
  "event-listener-strategy 0.4.0",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -571,33 +570,33 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.31",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
 dependencies = [
  "async-io 2.3.2",
- "async-lock 2.8.0",
+ "async-lock 3.3.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.31",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.7.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -607,7 +606,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -620,7 +619,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -637,15 +636,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line 0.21.0",
  "cc",
@@ -679,6 +678,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -726,13 +731,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.16",
+ "prettyplease 0.2.20",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -774,9 +779,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitvec"
@@ -846,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
@@ -877,18 +882,16 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
 dependencies = [
- "async-channel 2.2.0",
+ "async-channel 2.3.1",
  "async-lock 3.3.0",
  "async-task",
- "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.2.0",
+ "futures-lite 2.3.0",
  "piper",
- "tracing",
 ]
 
 [[package]]
@@ -914,14 +917,14 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e9ce60db859f26172c1428b251e628751850e7862065104e750310c6afbad"
+checksum = "0181e1058f555b2e0f177e82042a6edd9c342ed4ec826376b2e5aa1cd29fc853"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -932,9 +935,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bs58"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
 ]
@@ -950,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byte-slice-cast"
@@ -968,9 +971,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 
 [[package]]
 name = "byteorder"
@@ -980,9 +983,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bzip2-sys"
@@ -1007,18 +1010,18 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
 ]
@@ -1031,7 +1034,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.22",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "thiserror",
@@ -1039,12 +1042,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -1058,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa50868b64a9a6fda9d593ce778849ea8715cd2a3d2cc17ffdb4a2f2f2f1961d"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
 ]
@@ -1113,16 +1117,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1134,6 +1138,19 @@ dependencies = [
  "core2",
  "multibase",
  "multihash 0.17.0",
+ "serde",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "cid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash 0.18.1",
  "serde",
  "unsigned-varint",
 ]
@@ -1210,7 +1227,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1242,39 +1259,49 @@ dependencies = [
 
 [[package]]
 name = "color-print"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a858372ff14bab9b1b30ea504f2a4bc534582aee3e42ba2d41d2a7baba63d5d"
+checksum = "1ee543c60ff3888934877a5671f45494dd27ed4ba25c6670b9a7576b7ed7a8c0"
 dependencies = [
  "color-print-proc-macro",
 ]
 
 [[package]]
 name = "color-print-proc-macro"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e37866456a721d0a404439a1adae37a31be4e0055590d053dfe6981e05003f"
+checksum = "77ff1a80c5f3cb1ca7c06ffdd71b6a6dd6d8f896c42141fbd43f50ed28dcdb93"
 dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
+checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
  "unicode-width",
 ]
 
@@ -1286,9 +1313,9 @@ checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1327,7 +1354,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1508,10 +1535,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.4.0"
+name = "crc"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -1546,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -1610,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169c6bebaa58a8f0f2078747919ebd98df45d0d018a0f8caa66ec15e2ad43d4"
+checksum = "56af3de66b0512db180c091ccbf673ed198f75a25b602289ee247251bf966c39"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1622,39 +1664,39 @@ dependencies = [
  "sc-service",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "url",
 ]
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ffccac45cddcbb37b8c18283bd57638f648f725091d28c3ac3be515f8dd1d"
+checksum = "aeaa7ba76cb14097c15105674be6ec74e58bc1313cb322a97e038c9abfbf09c4"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-primitives-core",
  "futures",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d112f874c998d174f034532d238d5e0616c3455f8bf9bb5946c5617e7c7c0f"
+checksum = "a999414a27e99ed73f447aba5f9382bb81fbf3e98a8c1a8874f71f929d094759"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1677,17 +1719,17 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "schnellru",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
- "sp-inherents",
+ "sp-inherents 31.0.0",
  "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -1695,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6fc5e8237ff0e649c24fb1c31407fddb05cdf4773f83ca2a7b497305ae19b0"
+checksum = "fc06ef9519e39f72915033e0aec418383707290103c8d9ba8ffbc70ddfd515e7"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1716,41 +1758,41 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-timestamp",
- "sp-trie",
+ "sp-trie 34.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb01ccc8275a4ded0caf788e561c7400e630585d34feec8a22700cbbe44f8bb"
+checksum = "e8a533049ee548528aada1c09c5827c3a2fd8cce96ecb4ff1fca241abfef87ba"
 dependencies = [
  "anyhow",
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f70b5f3eb4385498880a74684be6bd17669f2a2b5c7db805eef16337af1d0cd"
+checksum = "b1da1f0f7be1258a0f1a4a43ca0dd4a1add8e2e639dceaf310fc136d6835fe00"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "polkadot-node-primitives",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
@@ -1758,16 +1800,16 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0342e88f2079d7b3287bd52b4e0f7885e563439ff2e8b8d36f99aa596b219e"
+checksum = "cb5426870af0eac3277135aac62dafea82f9c42b501193bca5483c2eb9358b5b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1777,22 +1819,22 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
  "sp-storage",
- "sp-trie",
+ "sp-trie 34.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e877fcdae06369ce17fd4d1fd0467d21b08338f7c944e225c5461472f54a166a"
+checksum = "286e7071e367a4ee6f1e9c674a27118c6f04ef273b94194082b8155255451503"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1804,20 +1846,20 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-consensus",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920c64fd704a14c571b79f5d0f19dd2638240f6a9f633f02072a35ab30db3341"
+checksum = "a909ed00f0280a9f53838616bb8f56b180116838a8242b847a18c8950e7cc4ec"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1842,39 +1884,39 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-transaction-pool",
 ]
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b720fe4cd7d2e6282c0c13fbbcf68cd7dcb19d060b5032709c34582d574ad"
+checksum = "fa2703d49952e0538c4d05fe1f1114e62741871693e862fc68ab56ae6b3b5230"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b426ade835b03cb4eb0b7299a5918e96cb53ed0e38b0d07676be7ed8df772ff"
+checksum = "249e7657ac378241ae6c437df851bbe0971d93df756d1201315395b5ce856974"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1882,9 +1924,9 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
@@ -1895,15 +1937,15 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 34.0.0",
+ "sp-version 34.0.0",
  "staging-xcm",
- "trie-db",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
@@ -1915,53 +1957,53 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b08b5e3bba454f8eaa01a7507c1bacde9343a7a67fc20801e59e0c9c0ec9db"
+checksum = "2be9d77e00ad1dbcf12dcd81c2758d651adf6e3072f3cb51c11d8739426f4cbb"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f14dc8bc002babf1596515a2f1c0158ddeccbf1ef7f5656fe71c8e1fa4bde55"
+checksum = "6b7737eb5d81bcd79df114e711927ba19c2dbd312f245ae03b76d330abb3506d"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5810a98c95f4219d7dcd6bd89d0c149fc45162e7e0c335579ba5545ec4b9c216"
+checksum = "fb2939bc9749f4a5299ae20f7756ce69ce3e63f72ed936d7f1db0189187f70a1"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
@@ -1969,8 +2011,8 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
@@ -1978,97 +2020,99 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5e91498fef0a7502070d55949b3413361060b1e0556592ed851f220f8aafb4"
+checksum = "a61fa5dad966e340092a4521b56b43dddce5bf466ddb07d9a01c534e63e4e0b7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-primitives",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a1b925068ede5dd9f571f3afcfca877b2f94f988d308d757224464a27bc6ce"
+checksum = "ad51d36ea156ef84d7e8ca5cea881867d3540e8dfdb8ea6b9d2b9190197a22a5"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 34.0.0",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01642f846368bd7305a2b9c9874a4280b5097c62c33da84b2048e2e3b38bb03"
+checksum = "9e6d358b1c4062048e47635b49d066131e4eef6314c0e81501d4c9c2e028dbc4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9ce5326ecf86a75ee9a2d53ba8a6950f98d278a1cc88480f1dcbc90077d7dc"
+checksum = "e736734a6b4b0308d931756c30c3472fa5ec99a95be14f70567f25c97b3822cc"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
- "sp-trie",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8596e26f2d3b2c70c00b695eb9edc8fca4533105bf6b2f0c4c0ecc8075bf99"
+checksum = "e68201ff0845be29c3c0e7e408e5f9d4de0e01b55787fe2c8709e658cbd2c937"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b02524805657a76fcca354c2a9466580d7f980a9a9616a4ac1cb91597d1f451"
+checksum = "5ee70eb2f55d20a965e3538fc96aac2801815af510b4460e8a5783f5197e0872"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
+ "frame-support 33.0.0",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -2077,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842505bb9820f5d3c7d2561ed9783cd495d3665729e42590b12641e73c69fcf5"
+checksum = "d9557dc83e9fa1ab863f6070f9d325a8075cb00478f2a756132ed87b4e3a29ed"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2093,18 +2137,18 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a457e637e70eccddfdd06feaf5736e3fa3fd9955ef2dc9ef696cdea640fc6e4c"
+checksum = "9ed3c0bd4319881da5f94b77380db377499e129a176184430b308d9d7bd1d9a8"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2113,25 +2157,25 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
- "sp-state-machine",
+ "sp-state-machine 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f946e5e8f6199bad20b4e65b3e56fb6feeb3c59d50ede9909dcfa9c73697db2"
+checksum = "d3ffcf7b86d4a140ba5ba6c94537ae54334c594bb4cf7a6464c848859b7970d1"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
  "futures",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
  "polkadot-core-primitives",
@@ -2152,11 +2196,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2164,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b173a09d24c4ea2b6f90eb682276f844db7b180651f22a9e918f8bac0642075f"
+checksum = "800d957241a91a58b55a3ee9f607caea2660a01d2fcfc285bdcec262a3d8882d"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2178,7 +2222,7 @@ dependencies = [
  "parity-scale-codec",
  "pin-project",
  "polkadot-overseer",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-rpc-api",
  "sc-service",
@@ -2187,14 +2231,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-storage",
- "sp-version",
+ "sp-version 34.0.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2204,17 +2248,17 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f27d17ab307b0e255431fa21113f2aca1e0b27f54d272198972b29e2eeb88b"
+checksum = "e8f509dfa3d3380fd0023f4cbd15bfeccd333de8d0140f85d13e6b295fb53dd7"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
@@ -2255,7 +2299,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2273,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.119"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635179be18797d7e10edb9cd06c859580237750c7351f39ed9b298bfc17544ad"
+checksum = "bb497fad022245b29c2a0351df572e2d67c1046bcef2260ebc022aec81efea82"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -2285,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.119"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9324397d262f63ef77eb795d900c0d682a34a43ac0932bec049ed73055d52f63"
+checksum = "9327c7f9fbd6329a200a5d4aa6f674c60ab256525ff0084b52a889d4e4c60cee"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2295,24 +2339,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.119"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87ff7342ffaa54b7c61618e0ce2bbcf827eba6d55b923b83d82551acbbecfe5"
+checksum = "688c799a4a846f1c0acb9f36bb9c6272d9b3d9457f3633c7753c6057270df13c"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.119"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b5b86cf65fa0626d85720619d80b288013477a91a0389fa8bc716bf4903ad1"
+checksum = "928bc249a7e3cd554fd2e8e08a426e9670c50bbfc9a621653cfa9accc9641783"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2322,23 +2366,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.9",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c01c06f5f429efdf2bae21eb67c28b3df3cf85b7dd2d8ef09c0838dac5d33e"
+checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2346,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0047d07f2c89b17dd631c80450d69841a6b5d7fb17278cbc43d7e4cfcf2576f3"
+checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
@@ -2356,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -2417,7 +2461,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2519,7 +2563,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2543,9 +2587,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.58",
+ "syn 2.0.65",
  "termcolor",
- "toml 0.8.10",
+ "toml 0.8.13",
  "walkdir",
 ]
 
@@ -2557,9 +2601,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtoa"
@@ -2605,8 +2649,17 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "serdect",
- "signature",
+ "signature 2.2.0",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+dependencies = [
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -2616,7 +2669,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek 3.2.0",
+ "ed25519 1.5.3",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -2626,7 +2693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek 4.1.2",
- "ed25519",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
@@ -2655,8 +2722,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek 4.1.2",
- "ed25519",
- "hashbrown 0.14.3",
+ "ed25519 2.2.3",
+ "hashbrown 0.14.5",
  "hex",
  "rand_core 0.6.4",
  "sha2 0.10.8",
@@ -2665,9 +2732,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "elliptic-curve"
@@ -2708,6 +2775,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,7 +2803,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2735,7 +2814,7 @@ checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2765,9 +2844,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2787,7 +2866,7 @@ checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -2798,18 +2877,18 @@ checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -2819,17 +2898,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener 4.0.3",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 5.2.0",
- "pin-project-lite 0.2.13",
+ "event-listener 5.3.0",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -2864,7 +2943,7 @@ dependencies = [
  "prettier-please",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2890,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fatality"
@@ -2941,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "file-per-thread-logger"
@@ -2979,7 +3058,7 @@ dependencies = [
  "log",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "scale-info",
 ]
 
@@ -2990,7 +3069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3003,9 +3082,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -3026,6 +3105,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-tree"
@@ -3057,20 +3151,46 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6f8e21cbac73688175cf9b531ed1c3f6578420a0f6106282aa8e5ed6fe3347"
 dependencies = [
- "frame-support",
- "frame-support-procedural",
- "frame-system",
+ "frame-support 32.0.0",
+ "frame-support-procedural 27.0.0",
+ "frame-system 32.0.0",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
+ "static_assertions",
+]
+
+[[package]]
+name = "frame-benchmarking"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f963589fa0f5ef5fe87fad5a9ac9ec4a43d83fd63e1993024576a8dcaee5e228"
+dependencies = [
+ "frame-support 33.0.0",
+ "frame-support-procedural 28.0.0",
+ "frame-system 33.0.0",
+ "linregress",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
+ "sp-core",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
@@ -3079,18 +3199,18 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be33471ac5fa10ca585d3e06642cc8c754ecd9cb8a76905bf648cff17990e32"
+checksum = "e13ce497c53ed3a9aadadfc3ea7904b00717965156c0e2e6dd16fc049a379cd7"
 dependencies = [
  "Inflector",
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "gethostname",
  "handlebars",
  "itertools 0.10.5",
@@ -3098,9 +3218,10 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "sc-block-builder",
+ "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
  "sc-client-db",
@@ -3109,18 +3230,19 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-storage",
- "sp-trie",
+ "sp-trie 34.0.0",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -3135,43 +3257,43 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c897b912f222280123eedee768b172ed74600292dfbb22843c95c9177e97358"
+checksum = "ee6e46fd5f6bbbce22fcb19bccce899b4e83e917ba5181b1adae94abb086f124"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbd97de3a8af65a9e1752b465fc19c7fe19c62ca1842ccec47f3002667c2172"
+checksum = "01d5b1ec42b019aa16d1f9269f74f391c32ce642cb2aad7b1b6a6d65a34e1bc6"
 dependencies = [
  "aquamarine 0.3.3",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-tracing",
 ]
@@ -3189,26 +3311,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-remote-externalities"
-version = "0.39.0"
+name = "frame-metadata-hash-extension"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4afeb0769c0ef010c0dcc681a60167692a1cd52f0c0729b327a4415facddc5"
+checksum = "c51ead97e4ac8fdd3b62258bf5f97d2d82412ec0386388ce8296aa23d561536f"
 dependencies = [
- "futures",
- "indicatif",
- "jsonrpsee",
+ "array-bytes 6.2.3",
+ "docify",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
- "serde",
- "sp-core",
- "sp-crypto-hashing",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
- "spinners",
- "substrate-rpc-client",
- "tokio",
- "tokio-retry",
+ "scale-info",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -3218,12 +3333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97100a956a2cd152ad4e63a5ec7b5e58503653223a73fff6e916b910b37f12ed"
 dependencies = [
  "aquamarine 0.5.0",
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "bitflags 1.3.2",
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural",
+ "frame-support-procedural 27.0.0",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -3234,18 +3349,60 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api",
+ "sp-api 30.0.0",
  "sp-arithmetic",
  "sp-core",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.11.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
  "sp-metadata-ir",
- "sp-runtime",
- "sp-staking",
- "sp-state-machine",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-weights",
+ "static_assertions",
+ "tt-call",
+]
+
+[[package]]
+name = "frame-support"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d04fc1fdbc7bdcb1cb54834e16a5194e5a16a25bfdaca1b761ee9ff4963366f"
+dependencies = [
+ "aquamarine 0.5.0",
+ "array-bytes 6.2.3",
+ "bitflags 1.3.2",
+ "docify",
+ "environmental",
+ "frame-metadata",
+ "frame-support-procedural 28.0.0",
+ "impl-trait-for-tuples",
+ "k256",
+ "log",
+ "macro_magic",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sp-api 31.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
+ "sp-metadata-ir",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
  "sp-tracing",
  "sp-weights",
@@ -3263,14 +3420,34 @@ dependencies = [
  "cfg-expr",
  "derive-syn-parse 0.2.0",
  "expander 2.1.0",
- "frame-support-procedural-tools",
+ "frame-support-procedural-tools 11.0.1",
  "itertools 0.10.5",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.58",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d8eaf3bb331b98427158733e221bd6fb79e9f213da55b305e159dc023d41fd2"
+dependencies = [
+ "Inflector",
+ "cfg-expr",
+ "derive-syn-parse 0.2.0",
+ "expander 2.1.0",
+ "frame-support-procedural-tools 12.0.0",
+ "itertools 0.10.5",
+ "macro_magic",
+ "proc-macro-warning",
+ "proc-macro2",
+ "quote",
+ "sp-crypto-hashing",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3283,7 +3460,20 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b5cc8526c9aad01cdf46dcee6cbefd6f6c78e022607ff4cf76094919b6462"
+dependencies = [
+ "frame-support-procedural-tools-derive",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3294,7 +3484,7 @@ checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3305,55 +3495,76 @@ checksum = "562e02f5139f1beb0edd3cac2db3f974d98b7459342210d101f451d26886ca33"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support",
+ "frame-support 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-version",
+ "sp-version 33.0.0",
+ "sp-weights",
+]
+
+[[package]]
+name = "frame-system"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64265317899a2ecfc465a1ab55fa3094dbbbc7061292592fdbbb8acc136c4735"
+dependencies = [
+ "cfg-if",
+ "docify",
+ "frame-support 33.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-std",
+ "sp-version 34.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4976a4dfad8b4abff9dfc5e1a5bcdfa0452765f5c726805499ea30be0df4eaa4"
+checksum = "1a23446bf524bcc64351ecc5a50925debdc92d50a0b8384c3064dc13b3c64ca3"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24451c0fef0c35c50bf577aadd16bb3c7b9eb74f12bb1708114d24c6f750e165"
+checksum = "54771ae481dd08825d4de28b1b3623163efd9e7c4b59a6db1fb048dcdf73789e"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 31.0.0",
 ]
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883f2a531ab7857e8b4bb09997f1333635da1b5e627ac1651c16b5e5152d8fa3"
+checksum = "8f542a58bd43234882faff12062ce94838b3bbca1b6ed6b32180ee153350905f"
 dependencies = [
- "frame-support",
+ "frame-support 33.0.0",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
@@ -3382,7 +3593,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
 dependencies = [
- "rustix 0.38.31",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -3452,21 +3663,21 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-lite"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.0.1",
+ "fastrand 2.1.0",
  "futures-core",
  "futures-io",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -3477,7 +3688,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3522,7 +3733,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "pin-utils",
  "slab",
 ]
@@ -3579,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3594,7 +3805,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "rand_core 0.6.4",
 ]
 
@@ -3647,10 +3858,10 @@ dependencies = [
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "spinning_top",
 ]
@@ -3668,9 +3879,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -3678,7 +3889,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -3687,9 +3898,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "5.1.0"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab283476b99e66691dee3f1640fea91487a8d81f50fb5ecc75538f8f8879a1e4"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
 dependencies = [
  "log",
  "pest",
@@ -3734,9 +3945,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
@@ -3749,7 +3960,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3778,9 +3989,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-literal"
@@ -3866,7 +4077,7 @@ checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -3909,8 +4120,8 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.13",
- "socket2 0.5.6",
+ "pin-project-lite 0.2.14",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -3927,7 +4138,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -3963,6 +4174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -4067,12 +4288,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4080,19 +4301,6 @@ name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
-
-[[package]]
-name = "indicatif"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
-]
 
 [[package]]
 name = "inout"
@@ -4105,9 +4313,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -4150,7 +4358,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -4183,6 +4391,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4201,16 +4415,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.10"
+name = "itertools"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -4226,12 +4449,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.22.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cdbb7cb6f3ba28f5b212dd250ab4483105efc3e381f5c8bb90340f14f0a2cc3"
+checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
 dependencies = [
  "jsonrpsee-core",
- "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
@@ -4242,9 +4464,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.22.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab2e14e727d2faf388c99d9ca5210566ed3b044f07d92c29c3611718d178380"
+checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
 dependencies = [
  "futures-util",
  "http",
@@ -4263,21 +4485,20 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.22.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71962a1c49af43adf81d337e4ebc93f3c915faf6eccaa14d74e255107dfd7723"
+checksum = "b4b257e1ec385e07b0255dde0b933f948b5c8b8c28d42afda9587c3a967b896d"
 dependencies = [
  "anyhow",
- "async-lock 3.3.0",
  "async-trait",
  "beef",
  "futures-timer",
  "futures-util",
  "hyper",
  "jsonrpsee-types",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -4288,43 +4509,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-http-client"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c13987da51270bda2c1c9b40c19be0fe9b225c7a0553963d8f17e683a50ce84"
-dependencies = [
- "async-trait",
- "hyper",
- "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tower",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.22.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7c2416c400c94b2e864603c51a5bbd5b103386da1f5e58cbf01e7bb3ef0833"
+checksum = "7d0bb047e79a143b32ea03974a6bf59b62c2a4c5f5d42a381c907a8bbb3f75c0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.22.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4882e640e70c2553e3d9487e6f4dddd5fd11918f25e40fa45218f9fe29ed2152"
+checksum = "12d8b6a9674422a8572e0b0abb12feeb3f2aeda86528c80d0350c2bd0923ab41"
 dependencies = [
  "futures-util",
  "http",
@@ -4346,9 +4547,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.22.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e53c72de6cd2ad6ac1aa6e848206ef8b736f92ed02354959130373dfa5b3cbd"
+checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
 dependencies = [
  "anyhow",
  "beef",
@@ -4359,9 +4560,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.22.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a07ab8da9a283b906f6735ddd17d3680158bb72259e853441d1dd0167079ec"
+checksum = "58b9db2dfd5bb1194b0ce921504df9ceae210a345bc2f6c5a61432089bbab070"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -4415,7 +4616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7a85fe66f9ff9cd74e169fdd2c94c6e1e74c412c99a73b4df3200b5d3760b2"
 dependencies = [
  "kvdb",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
 ]
 
 [[package]]
@@ -4426,7 +4627,7 @@ checksum = "b644c70b92285f66bfc2032922a79000ea30af7bc2ab31902992a5dcb9b434f6"
 dependencies = [
  "kvdb",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "regex",
  "rocksdb",
  "smallvec",
@@ -4434,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "landlock"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1530c5b973eeed4ac216af7e24baf5737645a6272e361f1fb95710678b67d9cc"
+checksum = "9baa9eeb6e315942429397e617a190f4fdc696ef1ee0342939d641029cbb4ea7"
 dependencies = [
  "enumflags2",
  "libc",
@@ -4457,9 +4658,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
@@ -4468,7 +4669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -4486,7 +4687,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
@@ -4551,10 +4752,10 @@ dependencies = [
  "multihash 0.17.0",
  "multistream-select",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "pin-project",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "rw-stream-sink",
  "smallvec",
  "thiserror",
@@ -4571,9 +4772,9 @@ dependencies = [
  "futures",
  "libp2p-core",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "smallvec",
- "trust-dns-resolver",
+ "trust-dns-resolver 0.22.0",
 ]
 
 [[package]]
@@ -4605,12 +4806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
 dependencies = [
  "bs58 0.4.0",
- "ed25519-dalek",
+ "ed25519-dalek 2.1.1",
  "log",
  "multiaddr",
  "multihash 0.17.0",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror",
  "zeroize",
@@ -4635,7 +4836,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "smallvec",
  "thiserror",
@@ -4657,11 +4858,11 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "socket2 0.4.10",
  "tokio",
- "trust-dns-proto",
+ "trust-dns-proto 0.22.0",
  "void",
 ]
 
@@ -4693,7 +4894,7 @@ dependencies = [
  "log",
  "once_cell",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "snow",
  "static_assertions",
@@ -4715,7 +4916,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
  "void",
 ]
 
@@ -4733,9 +4934,9 @@ dependencies = [
  "libp2p-identity",
  "libp2p-tls",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "quinn-proto",
- "rand",
+ "rand 0.8.5",
  "rustls 0.20.9",
  "thiserror",
  "tokio",
@@ -4753,7 +4954,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand",
+ "rand 0.8.5",
  "smallvec",
 ]
 
@@ -4772,7 +4973,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive",
  "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "tokio",
  "void",
@@ -4820,7 +5021,7 @@ dependencies = [
  "rustls 0.20.9",
  "thiserror",
  "webpki",
- "x509-parser",
+ "x509-parser 0.14.0",
  "yasna",
 ]
 
@@ -4849,7 +5050,7 @@ dependencies = [
  "futures-rustls",
  "libp2p-core",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "quicksink",
  "rw-stream-sink",
  "soketto",
@@ -4872,13 +5073,12 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "libc",
- "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -4909,7 +5109,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -4946,9 +5146,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5002,9 +5202,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lioness"
@@ -5019,10 +5219,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
+name = "litep2p"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "9b53e78902be9d0d77df70677242b7fc9815a33a168949b5480ee089e16535e7"
+dependencies = [
+ "async-trait",
+ "bs58 0.4.0",
+ "bytes",
+ "cid 0.10.1",
+ "ed25519-dalek 1.0.1",
+ "futures",
+ "futures-timer",
+ "hex-literal",
+ "indexmap 2.2.6",
+ "libc",
+ "mockall",
+ "multiaddr",
+ "multihash 0.17.0",
+ "network-interface",
+ "nohash-hasher",
+ "parking_lot 0.12.2",
+ "pin-project",
+ "prost 0.11.9",
+ "prost-build",
+ "quinn",
+ "rand 0.8.5",
+ "rcgen",
+ "ring 0.16.20",
+ "rustls 0.20.9",
+ "serde",
+ "sha2 0.10.8",
+ "simple-dns",
+ "smallvec",
+ "snow",
+ "socket2 0.5.7",
+ "static_assertions",
+ "str0m",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "trust-dns-resolver 0.23.2",
+ "uint",
+ "unsigned-varint",
+ "url",
+ "webpki",
+ "x25519-dalek 2.0.1",
+ "x509-parser 0.15.1",
+ "yasna",
+ "zeroize",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -5096,7 +5351,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5110,7 +5365,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5121,7 +5376,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -5132,14 +5387,8 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "match_cfg"
@@ -5152,6 +5401,15 @@ name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
@@ -5174,9 +5432,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memfd"
@@ -5184,7 +5442,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.31",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -5224,6 +5482,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes 6.2.3",
+ "blake3",
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-info",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5242,7 +5514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69672161530e8aeca1d1400fbf3f1a1747ff60ea604265a4e906c2442df20532"
 dependencies = [
  "futures",
- "rand",
+ "rand 0.8.5",
  "thrift",
 ]
 
@@ -5254,9 +5526,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
 ]
@@ -5288,8 +5560,8 @@ dependencies = [
  "hashlink",
  "lioness",
  "log",
- "parking_lot 0.12.1",
- "rand",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.5.0",
@@ -5299,38 +5571,38 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463f3038aebf0766b75c231e293293dec7b85f2358120a2696470159008ddfd2"
+checksum = "686cce3698548808445b0bbc8348a30cafc7d6fc6dbf8df0ef5027b08e4fe037"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "mmr-rpc"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17ec87c5d04009e7d7b149abb2aa8495e2893c5920ce4a83679c76e5d6320f7"
+checksum = "70db3d6f4fdfd688a4f995f5eb3ee9764b766a01f4a4789fa5469a02d213ee12"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -5413,10 +5685,14 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
 dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
  "core2",
  "digest 0.10.7",
  "multihash-derive 0.8.0",
  "sha2 0.10.8",
+ "sha3",
  "unsigned-varint",
 ]
 
@@ -5511,9 +5787,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4541eb06dce09c0241ebbaab7102f0a01a0c8994afed2e5d0d66775016e25ac2"
+checksum = "3ea4908d4f23254adda3daa60ffef0f1ac7b8c3e9a864cf3cc154b251908a2ef"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -5542,7 +5818,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5606,15 +5882,27 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
+checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
 dependencies = [
  "bytes",
  "futures",
  "libc",
  "log",
  "tokio",
+]
+
+[[package]]
+name = "network-interface"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+dependencies = [
+ "cc",
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]
@@ -5634,7 +5922,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "libc",
 ]
@@ -5686,21 +5974,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.4"
+name = "nu-ansi-term"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
- "autocfg",
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
@@ -5732,11 +6029,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -5744,9 +6040,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -5761,12 +6057,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -5817,10 +6107,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-src"
+version = "300.3.0+3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba8804a1c5765b18c4b3f907e6897ebabeedebc9830e1a0046c4a4cf44663e1"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -5830,9 +6168,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestra"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2356622ffdfe72362a45a1e5e87bb113b8327e596e39b91f11f0ef4395c8da79"
+checksum = "92829eef0328a3d1cd22a02c0e51deb92a5362df3e7d21a4e9bdc38934694e66"
 dependencies = [
  "async-trait",
  "dyn-clonable",
@@ -5847,15 +6185,15 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eedb646674596266dc9bb2b5c7eea7c36b32ecc7777eba0d510196972d72c4fd"
+checksum = "1344346d5af32c95bbddea91b18a88cc83eac394192d20ef2fc4c40a74332355"
 dependencies = [
  "expander 2.1.0",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itertools 0.11.0",
  "petgraph",
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5871,56 +6209,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-asset-conversion"
-version = "14.0.0"
+name = "overload"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66fbfb4b9a3a6430f5925a09257c61a048bf0dfbad26f814e0f0e517f43c06a"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pallet-asset-conversion"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00878f866191e08a7f6a74a0378c1d4d759e356d5fc3e3dae51fa414b44fad93"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-asset-rate"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a63f90c10e0746fce0512e37e1a354fe8c48f32e4e20211e0c1ac9b0e4b3febb"
+checksum = "a2908c5abe694fc6d1e9f1dbc9049910cf7086416e0c3214ff4734f02c055d82"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27f76cc9151160c08fcee2e095b91048a2d1cb041b7c022a88f98ba220827b4"
+checksum = "cbdecfbbcc55a4050a91bf2180b5b574fe3e20a925c1a836187041974c6f9248"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
@@ -5930,140 +6275,157 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda0d9362dc1b75cead58f5e9a6004d305f81b2bf38c52e5454d1d868e2cc98f"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-assets"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14bb2544de653caa76f88156c53ccdea218737ae00ef37b949786bc4c13719f8"
+dependencies = [
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-aura"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb27318bf97e8116b1383c726427ab8d6d9dac4da99c8540a247518398c2a55"
+checksum = "7d39e0cf359277a802199f4f78604ddb62f6616e6c625a3b958abec063b1a66f"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303077e7ec8808fdd9df22a6eaf9d38932a9b7df07c29423935384cf43babb2f"
+checksum = "35807c44d2caf67038ae3b3cd948a36014a63e75f96bab3754350deec7cf8e20"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-authority-discovery",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-authorship"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3544ca79d7b1f3b9a0efe6b54038143962e8b05d57a3a4172cd11e7216c43d6"
+checksum = "a9c6fadb06cb9f04998aebabf282e15a6bc35ac36de0c6fccb43a0efb38a755c"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-babe"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac02d082761843190fddfea58ce3a8cf042e92d2d78bb21426d2f960880a875c"
+checksum = "d1e8bc4e03c6e92cfbac89e9b505ff43fae538915fc277f4597733775c49fa76"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-babe",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bags-list"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664e6da2fe296a6597f2508f8754bfedaf06b5fc7bc657f7327b7d91896f84f7"
+checksum = "235a798b0ef83ef012fe79ed01617d84882e682aa40b937ca22e23ee429ab2d7"
 dependencies = [
  "aquamarine 0.5.0",
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56b559fbf1b04e08f42b08c0cb133cf732b4b0cafd315a3a24ba1ae60669d7e"
+checksum = "06c00a7041511735547ac443a14ecb2915976725dfbf1d3d9f64df20359e483e"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-beefy"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36b750d43f02589284a26ae4bcdaa9cd957abd12ffcedccf5de7f3ede20e14e"
+checksum = "42a846fddc17ec4bb5901f446a1f474090de2778c215aea9ab209631c88cf879"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6071,22 +6433,22 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0ec062385375cee83f44985bf4d32c86e6ca4018e0a867b448a9a572896388"
+checksum = "b59f46e15d62db39a20fb254324f5a33cf3c652ca6aa656ba6419ae5c8059336"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "binary-merkle-tree",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -6094,380 +6456,382 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus-beefy",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bounties"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe92916d8bb2f2ce84195ae5e6baec83c5a65bf685613d7cc207f0b8fd26ea43"
+checksum = "56765a826bcdc19693fc327757108d79ac03e7545bc3561a2434bb0238679ee6"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-broker"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d73ed3f977ca5874e32936f7605e83e96f7eb0cb7fca46b9a3f5a8df1933d5"
+checksum = "58e06a681df643f0bf7225c09b4d33ceaaebfe6ebfb13d0ea686f11d20901e9b"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "log",
  "parity-scale-codec",
  "scale-info",
+ "sp-api 31.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-child-bounties"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5612487abb09a9e5b6f3a694639fd0826a8b3bae1335047899f032f292f7f410"
+checksum = "813290bcfde2e10ad4a37763642e22186e28cf7d675cbf525f2276151444008c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-collator-selection"
-version = "13.0.1"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0724831b2b1775542055c80918e78478953ee8d6777962a947404f22001c75"
+checksum = "7b8c0293db4d8d6632330e8ea1d8ad83711c144fe8b03a14ae15fe1678c7291b"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "pallet-balances",
  "pallet-session",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-collective"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f84d7ad169667bcf184da694db6322bd9a68d9d0bb05b2727005cfadd2b8a17"
+checksum = "c2f5bea608ae6d9e8e12cd1e57d4781ccccf62a87e498bb6318ffe2243815ab4"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43080685819927c77fb38dda17e593eab2478406d674dd8c69200129cf613e77"
+checksum = "f0b8fc61dec0ae9760f00fb84a621e383ebb0bd1d2f6a4777bc55977624da5d1"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83740afbabdabd41a9af23e1085db431b7d0aa10e542f6e1862aa14ff76eeec9"
+checksum = "fcb285cd2c58b49219c9980b9c30d4c241920c5a55ae5df44c6e3649dd5057fd"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4127300982c54fb31630a3a002daeb060556c0d0ca17031975fe25d613f432"
+checksum = "45d7050267a6ce48b2d5530ea5c3b939c8f8a70e42b26db96cb1e859a3dd40c9"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
  "strum 0.26.2",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d47f77fc73b1caf6317515e884a1451786c8b71fddd910b753a73da7ee4fe84"
+checksum = "3cea3c30507dd5bc3ca2657a2b729dbb9c77f0ae7103778e148d4667d1f0dfe6"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-system",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08fe6701c248d87e489e998230180b112e639db09c0a50cf6e44cf399bc1028f"
+checksum = "e4482e691c61ea7d68d09a0d3221a2223b36118874c1923a3733a0ff1a9d4a65"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-npos-elections",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2f9df9cbcba5c986e8abb00dc6184cacebcd96064f706bbd47c870255fa4f1"
+checksum = "3413d41515d5679fa680f96ceac185ede18ac22002837216c9fab863d4a367b7"
 dependencies = [
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6beb51686baee78fc838861b825c1b8f1b66a7633dc502dc70da491aed82dcbb"
+checksum = "63024f2e3aee907a345db4993982b0a853cc330e487d0b7aa2b63bf956bb2a04"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-identity"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e41c45a18b5e71b05fd5789b210ce79dbddd454e9bc783dd188790be99d91"
+checksum = "4b59201c3a7fad2acc3623e0e933359588e86ba6445ec4e2ced9a56cbc150658"
 dependencies = [
  "enumflags2",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-im-online"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c771c379dfa58623a6d88d021c7cebe1f9f4f4537155917f7a9c03b5b36c3ec"
+checksum = "859266edee477b8d7c8f07bbe48956f2d0093b7a7466b473df66e6de4dd59445"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-indices"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b75dd0463b1ac775e8d154879e174e06fb8745b0896b8d9a3bd99d57135e914"
+checksum = "81babd3f9b3af66f27f7af6dfdea1943d16598630c5f4eda34ec56bdb7185dbd"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-membership"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d889d1ab1f8c78dddbe5aa107ae0004f066a79384af010e58539a71c84cbe1"
+checksum = "6d72c43d36e246e388b911ce85176962eeaf7893acb472fe1c4377c7007f886d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-message-queue"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd58fa73c9e498414c9e6757f5ff1dbb81b9c7439231018c19aca99c35fd35b"
+checksum = "55cf3baf644a42f0520f030e91e24c72e3d6691f7abc347345219b2e744fc835"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-mmr"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe22ce913c1862862a7ce3180b1a52b544a04a629b92c6dff43c3975ee89d39"
+checksum = "02f6cdaa2b8423f910e260b93065b8c63c7ebbc21c288419bc7a9aa0ed7a14fa"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-multisig"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b3d75a9319f7bcb58920ecc087aa246cc4cac0bcf5c9f29bb44260315961db"
+checksum = "4957a1571ca0a761520942623d7d1ff71f2831edfc2f2fc43ad454682e50ad95"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
@@ -6477,15 +6841,15 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677e05e538410a056620e737a4b9c9073a2636fcaab99609a57d0c706af4b186"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
- "pallet-assets",
+ "pallet-assets 33.0.0",
  "pallet-nfts",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -6496,15 +6860,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190767bc88a1a23f51fccc445a271639fd5a88f1811291d801221e5b9b5b48cc"
 dependencies = [
  "enumflags2",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
 ]
 
@@ -6516,108 +6880,108 @@ checksum = "b086ef37b5a2ab6d9c67929bd26480dfc128023039f238f6bc2b25a7348c1232"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 30.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nis"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f73f50b2cfeb31dad13e3bd628245bf9f2d8edc98ba3c7591c2f3303304a185"
+checksum = "c9317c665f1692637b3ede02fef4153ae3c4a4fb4b196bbea07a6a011546ab74"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e763dbe561c25187466eabb92d6193ad6098fb656a0dc807ebefbb237f903171"
+checksum = "c1edc38d7ba687163bdf2562b1fd8d440d63648c193b6c9e899ea12a607747ed"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
  "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a563a0a45f55c747819f1220adc27e492c5c7040e3a4f597d6e0e959f9742aa1"
+checksum = "ebd63c332aa3c111d10268c29aa439180d4b94c8adecbf526f0a04aeea46bea1"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-bags-list",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-runtime-interface",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce49d48a75a006539583808e526d303a09afd8621d3351ad52f8a4ca62fe8a8"
+checksum = "e3980bcda50ec619f93dbb8b73f824413ee5dccabe3511fca4454c49857c1483"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-offences"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621a7fe9a24a3f69cbb14b06c94894b81ad0aa549dbfff178c9236876cf5a892"
+checksum = "0d02ba6a9a9c27685404f979534ab254f0cda028857ebdb19f7cb9aa0f52bc6b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2c55d655bb56fb48c12fa98f1b6ea292ff58a0cf791cc7c180bb77ea73ac83"
+checksum = "de8b5190c4421f6550504bd1753f82492c28cda5b1ccb6c2759494cdfa431207"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-babe",
  "pallet-balances",
@@ -6628,206 +6992,225 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-parameters"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d8bc500ff1d3292950a7d1b50b0e26f7cd9f886cd4a577883267d36a1da1361"
+dependencies = [
+ "docify",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-preimage"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28de923b335df5fc38c9e0b565230120184f5e195624a386cd9bec90fda4b55"
+checksum = "a20718f6531ad2adf84ed0b1f845f29e29987b7fd1ccb738134c60e77177f1d0"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-proxy"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936d02c265142821c0144336d6724ec1fc56ddf333837f5ab502798fab5a447e"
+checksum = "a73160cf5aa5ebf1f07eb1134328b272ab16070028c8c1ee9f800ffa3a5c03db"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6a4587dc3f5438631db3c2ec019f31723c4a7949cf63945f111b6c509d0a97"
+checksum = "082ef6517f3901106bc642a7bb35b9c8345cbe55c5c60dbf6b09081b2e3c5695"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-recovery"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2320f4d3b35c47180c80a6ea560d25e491d5812486c8691bdd297b5425f11b"
+checksum = "06afe44a0484ad3c8b943c555fe4d7ccc9da3b3cd1093ddb6a8984bae6f130f4"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-referenda"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5abb788c5e8e7960820288caa043f5d037a63248453d493e617a2445790a4"
+checksum = "6b6c4f5bc65be570a065907239d3215036d3e29edbd0ea5c6cd01246e2ba3959"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-root-testing"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd630721c9f07bdf90e4cade8f825d1842af9f68f470de186087a3d1f0090970"
+checksum = "2e4b63ec79ab485d54cf79fd5ef574bb7f8f4e094e4a7d11b012a820d4324b62"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-scheduler"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fac215d9cf301396720219c4d04e4fe7fcf44d14d4be71f9c3ae3df3cead74"
+checksum = "7570e307118a4663dd3a1d1c949f84a169ef932666e69f7fcf4357781c8c1a4e"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061827f23d4a702a2e159ff84286a0a89488615c31ad05a9af7cc93a57e2b441"
+checksum = "925f793adb1d53c05233ffd2644ca37890d56c9716475108b975969a445d10b3"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
- "sp-state-machine",
+ "sp-staking 31.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817dd673f7d0b965639d27def260f7ff7a1535f2c5016a611445a8e4dedcf5cd"
+checksum = "ca61297e13c15fef1e4d3b7f2884e70c772be3a9448977ba23954e2c4bcea4bd"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
- "rand",
- "sp-runtime",
+ "rand 0.8.5",
+ "sp-runtime 36.0.0",
  "sp-session",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a89d24f9a15ae30d56fb9de190200d43735f4c055dcbe1c1259d3d4219da42a"
+checksum = "8584534df25227dd43d80803ea1978af55bf70aad5aa57c83dc3de883b1f1c73"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "scale-info",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-staking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8ab61dc6b74c79ad396732c1850dafa89109b749b2b651a1d4f20f45f596a3"
+checksum = "f68e48f3d79e0cbb9462eacc0c85c80003924124a893465047f159278338036d"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6835,10 +7218,10 @@ dependencies = [
  "rand_chacha 0.2.2",
  "scale-info",
  "serde",
- "sp-application-crypto",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-application-crypto 35.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
@@ -6851,7 +7234,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -6866,66 +7249,66 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8792b235b42d70e177301cd7e2e2b1afc828f1a6ddfa0639c481cd0c125078"
+checksum = "c431ab74db8258b39fe829fb7345d38064ef7fb1ce2014b074f586303d7dee67"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-staking",
+ "sp-api 31.0.0",
+ "sp-staking 31.0.0",
 ]
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3e2b1355eb2e08c2de3b14b175decf8ed49bf50de6cc44f97279257c325694"
+checksum = "9db0ce6ccf9e1d2fe2d0b26cecce995e4b095b31bbf9f0492024fbfd4924961a"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-sudo"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abdecbca3760e93bb757313495ca7d2437e6141e728a2d266a85884c43d74c0e"
+checksum = "10ee43e8bb38a50a234ef49198413483562e229ca20d8e9d9f78b756244f6d7c"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196720afcbee2f2fd1acfed5a667cffb3914d1311b36adb4d1a3a67d7010e2a5"
+checksum = "5982a7cc371e2b9be504465bb6e47bc27dba0b98ee9794d7fc797c24244fb6d9"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-storage",
  "sp-timestamp",
@@ -6933,158 +7316,158 @@ dependencies = [
 
 [[package]]
 name = "pallet-tips"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3c596b6fb68e70f890436d212af74d19154be438ae0255e5ddeea10e5ec91a"
+checksum = "84e0d02dcd034cb57cb25f1301c6e6c43b8191b96b049e7d013564aaf5d3c6af"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dedf412abd258989da4a26946f7e480c4335ffc837baef4ef21ba91cd56ba8ee"
+checksum = "aad5b92a96c4e38c7917477a1e5f2916c64f667f2734b2bf790ce552ceada82c"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95122a5483521f5186a008326514e5a579931cc1d36980bbca5bb2b566ca334f"
+checksum = "46ba896951ef39011e27d0a91b565520636f926f01b1c912a411146af079ef5e"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d4686402973e542eb83da077b46641643834220fbae74a98bcffa762d99e91"
+checksum = "f274055d2c61888689889d6e9b9266b163e1ed298967b55bf961db26b11a60fe"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-treasury"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac957446c936a57417ff7a4866f3463f7f2f49d9bb2daed81093c2de8f0cceaf"
+checksum = "23a11166748c80a432c52d5cc99c2b0e1d2b88592e0ad71eec7cb9f360e375c7"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-utility"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d770b7c961afe12adc5a727a5d02b44ef09ce38d1dd5923793b3e52e5afde3c"
+checksum = "eb1c70a4abf287304214b16d9eb88f13c991bd696f9e5318fc68e74df9802037"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-vesting"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ce37af22cc31883dfdafa334c4e1f7cea8f2d4fb964f3aa88d77d5eea7ba94"
+checksum = "d9a5b229675f299af7aa40749c579570dce4ab19739779a45f5a87da118af8ef"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-whitelist"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f118e773504b4160eb199d5504d3351d360e9ba64197d72384ee0c5ce1c0e1"
+checksum = "249172db9f2b014a6e9d4b5c6d663bcbcb0055c1c2c7564e7bd0488ecb1f15b8"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-xcm"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649a096b0c178cb81b0e11fac4d2c67eda7cdae949d2a4c7ef693d2b39d677c6"
+checksum = "db9e654cf90682370fe20a04904cb02df993c3b0dcfad861abcf2811f4fa6085"
 dependencies = [
  "bounded-collections",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -7094,18 +7477,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14af05792aec4a80c211f029ddc370cc3b0d2153f8adbbb0982d637768837bf0"
+checksum = "60b7038af027fcce5ba3d2f99b941fb997a5556f1fa0b8a7e7e23a448be1bb85"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -7127,7 +7510,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-benchmarking-cli",
  "futures",
  "jsonrpsee",
@@ -7155,14 +7538,14 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-aura",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-timestamp",
  "staging-xcm",
  "substrate-build-script-utils",
@@ -7183,16 +7566,18 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-utility",
- "frame-benchmarking",
+ "docify",
+ "frame-benchmarking 33.0.0",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-metadata-hash-extension",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex-literal",
  "log",
- "pallet-assets",
+ "pallet-assets 33.0.0",
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
@@ -7213,18 +7598,18 @@ dependencies = [
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 34.0.0",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-builder",
@@ -7234,17 +7619,17 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375e035fedfe5e0a6b4de6d29c56f8ed5ca64f421a883e7e5bcdc37a76a7c715"
+checksum = "43acd23527a3471b1c596b809591edf78d6113bba172fff4a96412d560dfea59"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-asset-tx-payment",
- "pallet-assets",
+ "pallet-assets 34.0.0",
  "pallet-authorship",
  "pallet-balances",
  "pallet-collator-selection",
@@ -7255,8 +7640,8 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "staging-parachain-info",
  "staging-xcm",
@@ -7271,7 +7656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -7291,8 +7676,8 @@ dependencies = [
  "log",
  "lz4",
  "memmap2 0.5.10",
- "parking_lot 0.12.1",
- "rand",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
  "siphasher",
  "snap",
  "winapi",
@@ -7300,9 +7685,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.9"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -7315,11 +7700,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.9"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -7356,12 +7741,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.9",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -7380,15 +7765,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -7410,9 +7795,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -7447,9 +7832,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.8"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -7458,9 +7843,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.8"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -7468,22 +7853,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.8"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.8"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -7492,12 +7877,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -7517,7 +7902,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -7528,9 +7913,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -7540,12 +7925,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+checksum = "464db0c665917b13ebb5d453ccdec4add5658ee1adc7affc7677615356a8afaf"
 dependencies = [
  "atomic-waker",
- "fastrand 2.0.1",
+ "fastrand 2.1.0",
  "futures-io",
 ]
 
@@ -7567,15 +7952,15 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9022a11f7a24b293242c08357ab90ca725b9a9153489fae32425ff8d43401dee"
+checksum = "3910a07cda88fd7e19c053f2fdfdb3296c8d55c033a71a642e531faa6029b9d2"
 dependencies = [
  "bitvec",
  "futures",
@@ -7588,15 +7973,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bd08d1b8eeaab90585e50da11114827dbbd0fdf1e6e2a417a57dde01b40d8"
+checksum = "1af6a6893b41ec4eae652ca62537694c9fac71f261bec4e8e26ab6ffc21faf78"
 dependencies = [
  "always-assert",
  "futures",
@@ -7605,15 +7990,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74aab8badb2e230830978ea27a34749ec6d0a096ff5c12fb08935f85e7881283"
+checksum = "f67b7867d8ddc0fe39a462dd6fafaf545be013e0a1c404cbd9a8de802ce6df82"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7625,7 +8010,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "schnellru",
  "sp-core",
  "sp-keystore",
@@ -7635,9 +8020,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1366718a28780768e5f2bd00c28445b0d37be21829b071a8b763534411978d81"
+checksum = "e2547ed0976533c8ed1247187dde1663fdbe5ab366efaae80085bb4b8b410e21"
 dependencies = [
  "async-trait",
  "fatality",
@@ -7649,7 +8034,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-network",
  "schnellru",
  "thiserror",
@@ -7659,9 +8044,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cbe8ee58650efc6a414c940e0bc09462926cfa806ace62207297f6a78c65a7"
+checksum = "ce323170edf8a3bb2cb6c2499642e44b8d0dccd60b3b20f9e2b9d776d53302e9"
 dependencies = [
  "cfg-if",
  "clap",
@@ -7678,20 +8063,19 @@ dependencies = [
  "sc-sysinfo",
  "sc-tracing",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-build-script-utils",
  "thiserror",
- "try-runtime-cli",
 ]
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdade551b33b767772d5bca1e19e4b8ea3dadb0154401dac2e578d9f73889d55"
+checksum = "87729af58fda6bccdcf0258d6657ed9150a7f1fc31b3f22fa22dbdd57e1f4f59"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7704,7 +8088,7 @@ dependencies = [
  "polkadot-primitives",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
  "tokio-util",
  "tracing-gum",
@@ -7712,28 +8096,28 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9792d6e3323b0bd7372a489bd3dd52afb09436919d073d45302f8e55f48ea4fd"
+checksum = "ef3c192d31bad69f561437549b3619a6cf02eae51d7f331efef7cfc6a56d61c2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c223fda0baf1414d963922e555001b32f6c13308b8b47081fa75959933cf2c"
+checksum = "a67943660c3f3b0ee6f05b42c0efbf1db282f5da18552a44769d3578209c5eba"
 dependencies = [
  "derive_more",
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -7743,7 +8127,7 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-keystore",
  "thiserror",
  "tracing-gum",
@@ -7751,24 +8135,24 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf840ff7a6337715e20e1afd76fd20dae11ebb049d89855ee2bf47b36b0e6249"
+checksum = "ec005dad44aeca9a315e182039a7c28d08fb57822073685dd1a0bb7827993fcb"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "reed-solomon-novelpoly",
  "sp-core",
- "sp-trie",
+ "sp-trie 34.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "477f94e8c3eedd6cfcfdfe50a33d610d38dfec4668ff7f3baef8814ffb7da85e"
+checksum = "85eb9555f3801a69e01c9559327b65e9b8e2532f45d739648e398bba52fbe50f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7776,11 +8160,11 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
@@ -7789,9 +8173,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bada301d390179f38d18f10435412c81f35fc8f6e357ed84516ca0018f8c6e21"
+checksum = "c5be1ffa029e0c3eddb50041a13c9ff3d66554effb63aaf78c61c2b10baf9b1c"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7799,7 +8183,7 @@ dependencies = [
  "fatality",
  "futures",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
@@ -7813,9 +8197,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81555b3a87382c8a7c5660b0b8a09dfd2573615086e7351ef95475a17e76b2d"
+checksum = "6efbc62e46127f70a0502dfe5c3f058166425e62c67227028f87a4fb908ba06e"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7832,9 +8216,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e3f49e8102d9a0b20f6f96199040ea253708b34bd30e679481228ebf76ab23"
+checksum = "15fc22bda776143d65bece22258364fa84d813164b742bc228877fa8871a1329"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7850,25 +8234,25 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6fe8e8eaf3e368e93a24309d812bc1e5f91fe865a80c1c7cd182fe217c50a7"
+checksum = "52df6f52e1e4a87b52c98b191cf37f14bf0c85fb73c792a10d86d4c9884170ed"
 dependencies = [
  "bitvec",
  "futures",
@@ -7889,9 +8273,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5417cf48b5948ed665f847240135f1fa5415cc5d3e9013cc3140a632cbf156"
+checksum = "8785e8abeef80825f48f581b34386ec92e4d4edb78256836a5723f7c2a33003d"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7910,9 +8294,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2365e3ddb8073f54e81b222e51a364cd3e38b7371bcd042017b73db2d523028"
+checksum = "d5855878573327e0975457dfea64b94081254ccd27ed32db19e2c3e9c11da832"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7926,9 +8310,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867b7c560556d063b4b93d0cec3a5f6932735311b5d66666105705b87fc36a9c"
+checksum = "87bef20a6df020d75b2750ac2b7926e17305588508f2ecafcf486f104145b337"
 dependencies = [
  "async-trait",
  "futures",
@@ -7948,9 +8332,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ffcc24bbbc2a2523c599022b106f0b48213bf80ef75f490fe02ec79ab972e4"
+checksum = "e7f0c8062fd9dcae3ca07ef32881e796979d7171187de3cecddc128bb03740fd"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7963,9 +8347,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9971f3ef6226f6f12bede58e009aae16fc6fc636159ec1dc7f1add2bad87638"
+checksum = "77d6f7ea52ddafcc80371a6e619e7c2247f1e2373b97180397ff832bd5a49d89"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7981,9 +8365,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d839dc81ec2f6593fb33bfc4d0e469c56ee0953fd129cc10fe224f7f2ff0bd"
+checksum = "aeb9022aa49a3cfaf5c452dcfb41f13511599409e569be527b229c3a94311b1f"
 dependencies = [
  "fatality",
  "futures",
@@ -8001,9 +8385,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3f8faa7a013b08ebdf4e018b8f7daccfc2b13fdac154d361ceb5be9992647b"
+checksum = "651b0dcf8d948b80c1980ccd973a7e3d666f30c74762a4f2b3b2312754936337"
 dependencies = [
  "async-trait",
  "futures",
@@ -8012,16 +8396,16 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents",
+ "sp-inherents 31.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5995f6998c35e9bbb8ab784714fcab7c9ddc6f0125cbd99a7175674a3f99f187"
+checksum = "e908f038f83eb28bf1ed586bb3bafb59907d1aebe0ae5ebdb4892a88eee1982b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8037,9 +8421,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccd98d226f1a650827183e6807466d0569691dd4a8434a3974eea041c73a677"
+checksum = "0dd8237ae0bba201d668f24aa574ffdebcc4af6ed265aa924b2ff99680a04eb7"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8056,18 +8440,16 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db5f945f8f26982b46c5cb1ed9c37f29d7e851bd06dae97b2b04e6d46dd4b77"
+checksum = "5987cd5501271b74a95664ee7f5ad1bd8e96c95b8c8bb7ca843b264ef5b086b5"
 dependencies = [
  "always-assert",
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "blake3",
  "cfg-if",
  "futures",
  "futures-timer",
- "is_executable",
- "libc",
  "parity-scale-codec",
  "pin-project",
  "polkadot-core-primitives",
@@ -8077,11 +8459,9 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "slotmap",
  "sp-core",
- "sp-maybe-compressed-blob",
- "sp-wasm-interface",
  "tempfile",
  "thiserror",
  "tokio",
@@ -8090,9 +8470,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275cab7ad2b38fdfb0c097485fe4f51e55e36c96330255edc38ccf121aa2171c"
+checksum = "dacfc74431199c07b35dcf1710fc800d158cb28bcc2e896d0dc2fa696cf08254"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8107,11 +8487,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1cf57c2204d9f80da258cfd1ca8e2ef7f366fa7810333da5f8519a05ba574d"
+checksum = "c9f5c0302abddbd120abfab4cf9de2794ac2aed3554d2741b0dfa79962595b22"
 dependencies = [
- "cfg-if",
  "cpu-time",
  "futures",
  "landlock",
@@ -8127,7 +8506,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-tracing",
  "thiserror",
  "tracing-gum",
@@ -8135,9 +8514,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9c685da442b6dde17f0f1e4bd6bb4d6827c6af0dbe96bc603d3d4f8fd05953"
+checksum = "581aab355ba6d81e05753f8fa401c928ddcda8d553dec4450abbc330956525fa"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8151,18 +8530,19 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbefc5402f4eadf6dc976d8013c0e050947809a1442a6fc3c44640841c7df712"
+checksum = "622b0231ea2b17096a69dcfb1a62ecb64ca3fcd91830efed0bf25c6b311c1eb8"
 dependencies = [
  "lazy_static",
  "log",
  "mick-jaeger",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "sc-network",
+ "sc-network-types",
  "sp-core",
  "thiserror",
  "tokio",
@@ -8170,11 +8550,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba41f6bbcb2261a92c452ffa2960301079a0922c832491b4e9aa3400887e33ac"
+checksum = "0cc571e16a460fb03319a17d037facb4924f549810e1fcacefbebc2c4cd2e3ee"
 dependencies = [
- "bs58 0.5.0",
+ "bs58 0.5.1",
  "futures",
  "futures-timer",
  "log",
@@ -8190,9 +8570,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915df9a38d99dc98216f8dce9a90f3ff2cee0d7fdf9b956c055844421b0d231b"
+checksum = "2761c570ac12f5dc48534cc39512118ecbfeb04116fdff5c4c79cf85263a1ab3"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8205,9 +8585,11 @@ dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
+ "sc-network-types",
+ "sp-runtime 36.0.0",
  "strum 0.26.2",
  "thiserror",
  "tracing-gum",
@@ -8215,9 +8597,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8d9fa95f0752c64635b2c8fc8c39b55eedb960f18a068d10720085c8ad06f6"
+checksum = "4e862d29bcc6b6d76ea41a08627edddb1f1fa071821019462f07e3bf53801336"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8227,21 +8609,21 @@ dependencies = [
  "polkadot-primitives",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
  "zstd 0.12.4",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5bbd86b3014ce7cc71e1a90bf641e26c4cea98955522d350268efa97c58de9"
+checksum = "bab90aceb1e00cb2eff617785f4bc8a40501f525359fb718d2c9ea5b90427d66"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8250,9 +8632,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca25de72c086250c6b53ba0a868fcb1c99c305e0abbf5e3faf5568310dd4672b"
+checksum = "c2973a2b608b792adc4a042f9d06d4eebfd63a05557c35bdd5040f445e26a680"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -8266,22 +8648,23 @@ dependencies = [
  "polkadot-statement-table",
  "sc-client-api",
  "sc-network",
+ "sc-network-types",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61ee42f50de06ae2d0209cb49af9805b780d1042a49f74f9841d2095784827"
+checksum = "d30298b2d686e24684754a5236fb8986c7c1777f8695ee81c61f5c69a891ef36"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8292,7 +8675,7 @@ dependencies = [
  "kvdb",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "pin-project",
  "polkadot-node-jaeger",
  "polkadot-node-metrics",
@@ -8303,10 +8686,10 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "prioritized-metered-channel",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -8315,22 +8698,22 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fa9663b506f2c6632468e1207e4a651ca16f2f4aba17d0a3d9e2fb828f02c5"
+checksum = "e5b0505f383fb8d474cef23cc1a8e24617cd9fd17ee44bbd13f5f92f98de53d9"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "orchestra",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "tikv-jemalloc-ctl",
  "tracing-gum",
@@ -8338,9 +8721,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe77e2febc4b87e7c0a63f857ce5c32a2680cae5f9c2740285cd7378ed1586ca"
+checksum = "549ecbe3c247ca2201e231801111ff4739fb1d66eb1421c2e5c0a2b153ac87b5"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -8349,16 +8732,16 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "polkadot-primitives"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71eabc294df35faa0877f6427e9a37d3b8323922aa0372cc9208e492d8f1b2f5"
+checksum = "ae78f3443b86249d5f7756177984d6b3c6b1af9432ff2a48e299be2c6ab97297"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8368,25 +8751,25 @@ dependencies = [
  "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-rpc"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb29231d3184c38d011a7bffea09a2c1724b5d7544d43d6159aaa3870ae74e26"
+checksum = "b791f93e89c38bafc894e9364c27a85b8d5696a9280f95f22c39a601cae4e6c8"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8405,28 +8788,28 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c9469b179e1bef848bbf051df1bd529b2b9a2a0428c0f87527586a5bca3848"
+checksum = "3effc5cafb231ede1c394abce9575c292e95170e11ee1ecc5644d25cf35b54b9"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
@@ -8453,14 +8836,14 @@ dependencies = [
  "serde",
  "serde_derive",
  "slot-range-helper",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -8470,12 +8853,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c04cc730f9ddcd9a663eddb95915d783704d11ea12eb2882c0abe18968b9de"
+checksum = "6cfaa021e4639e9fcba7c40111d93720b82cea98d667889760e46a40137e3d47"
 dependencies = [
- "bs58 0.5.0",
- "frame-benchmarking",
+ "bs58 0.5.1",
+ "frame-benchmarking 33.0.0",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-std",
@@ -8484,16 +8867,16 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32edd5b366f1e45995f613997ed259993cd2746f0407f186136696d54e24d784"
+checksum = "7b9f30223690133e9fbede03615c6b88aeaa774f777067d2253057ef35ba0270"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
@@ -8511,21 +8894,21 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rustc-hex",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
@@ -8534,15 +8917,16 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f276b38deaab6bff3ddfe061331901196ff992f76398bd0abc78382f4f115cf0"
+checksum = "fc6acbf05debbbab4831318fdbe0619742573dda47721af7e2ff042def2ec77a"
 dependencies = [
  "async-trait",
- "frame-benchmarking",
+ "bitvec",
+ "frame-benchmarking 33.0.0",
  "frame-benchmarking-cli",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex-literal",
@@ -8557,7 +8941,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "polkadot-approval-distribution",
  "polkadot-availability-bitfield-distribution",
  "polkadot-availability-distribution",
@@ -8594,6 +8978,7 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
  "rococo-runtime",
+ "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",
@@ -8620,7 +9005,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -8629,19 +9014,19 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-keyring",
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.40.0",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 34.0.0",
  "sp-weights",
  "staging-xcm",
  "substrate-prometheus-endpoint",
@@ -8653,16 +9038,16 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded486e00b2d5bdc589b4b75c722d7a2b2f4669bd3b492227d3501d60db1b4ec"
+checksum = "ca1a7eff92a348821650ed63e02c28a7ee2b5a76ef12d8289882a1e6f2e7de90"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -8670,16 +9055,16 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sp-keystore",
- "sp-staking",
+ "sp-staking 31.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-statement-table"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc9894c6ae63eb4ba1724cc4859db2224038b770b3ac1bf05f0650cbf01dca7"
+checksum = "4b879ec2b27bde2a05b70bd4826d7785c1e01ef72fc4a058d1055b1c95f8deb6"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8736,7 +9121,7 @@ dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -8746,7 +9131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -8756,7 +9141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7be503e60cf56c0eb785f90aaba4b583b36bff00e93997d93fef97f9553c39"
 dependencies = [
  "gimli 0.28.1",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "log",
  "object 0.32.2",
  "polkavm-common",
@@ -8782,20 +9167,21 @@ dependencies = [
  "concurrent-queue",
  "libc",
  "log",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "polling"
-version = "3.5.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "pin-project-lite 0.2.13",
- "rustix 0.38.31",
+ "hermit-abi",
+ "pin-project-lite 0.2.14",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -8878,7 +9264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22020dfcf177fcc7bf5deaf7440af371400c67c0de14c399938d8ed4fb4645d3"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -8893,12 +9279,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.16"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -8942,15 +9328,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
-dependencies = [
- "toml_edit 0.20.7",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
@@ -8990,29 +9367,29 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "thiserror",
 ]
 
@@ -9024,7 +9401,7 @@ checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "prometheus-client-derive-encode",
 ]
 
@@ -9036,7 +9413,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -9051,12 +9428,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
+ "prost-derive 0.12.6",
 ]
 
 [[package]]
@@ -9096,15 +9473,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -9127,9 +9504,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -9180,13 +9557,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8b432585672228923edbbf64b8b12c14e1112f62e88737655b4a083dbcd78e"
+dependencies = [
+ "bytes",
+ "pin-project-lite 0.2.14",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.20.9",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
 name = "quinn-proto"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring 0.16.20",
  "rustc-hash",
  "rustls 0.20.9",
@@ -9198,10 +9593,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.35"
+name = "quinn-udp"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
+dependencies = [
+ "libc",
+ "quinn-proto",
+ "socket2 0.4.10",
+ "tracing",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -9211,6 +9619,19 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
 
 [[package]]
 name = "rand"
@@ -9258,7 +9679,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -9268,7 +9689,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -9282,11 +9712,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.0.1"
+version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -9297,9 +9727,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -9346,12 +9776,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.4"
+name = "redox_syscall"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "getrandom 0.2.12",
+ "bitflags 2.5.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -9370,22 +9809,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4846d4c50d1721b1a3bef8af76924eef20d5e723647333798c1b519b3a9473f"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -9415,14 +9854,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -9442,7 +9881,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -9453,9 +9892,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "resolv-conf"
@@ -9500,7 +9939,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -9528,15 +9967,16 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1a30be097c0e02d2aacc4b2b73ecba2c795ae9246f2c37711ebae0e69dd95c"
+checksum = "224e7b002c0ba04bcee4bf25e2d90ff1895a9c1171fd8c3162c63a558c33a0d4"
 dependencies = [
  "binary-merkle-tree",
- "frame-benchmarking",
+ "bitvec",
+ "frame-benchmarking 33.0.0",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -9564,6 +10004,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-nis",
  "pallet-offences",
+ "pallet-parameters",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-ranked-collective",
@@ -9595,26 +10036,28 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_derive",
+ "serde_json",
  "smallvec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
+ "sp-consensus-grandpa",
  "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 34.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -9625,16 +10068,16 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa26847ef6b32b5fd41d4f86538ef15b8d74f208d211644dc14e4dda74559116"
+checksum = "578bde81aeca421df7d898726f0d3d9caea11eed87d77760be71177ce071977f"
 dependencies = [
- "frame-support",
+ "frame-support 33.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-weights",
  "staging-xcm",
  "staging-xcm-builder",
@@ -9684,9 +10127,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -9706,7 +10149,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.22",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -9748,14 +10191,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
 ]
 
@@ -9773,9 +10216,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -9785,14 +10228,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.4",
  "subtle 2.5.0",
  "zeroize",
 ]
@@ -9816,7 +10259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -9833,19 +10276,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -9859,9 +10302,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -9870,9 +10313,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ruzstd"
@@ -9898,9 +10341,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "safe_arch"
@@ -9934,9 +10377,9 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cd4cf9f2f6a12f1cc042831474f33103aad8ebf9fa6d49f7119521ed89b1ec"
+checksum = "4e4f35b9a8b91dd1232a26041c064d57b9f03ad2b80d2912512cfd1e4851e506"
 dependencies = [
  "async-trait",
  "futures",
@@ -9945,29 +10388,30 @@ dependencies = [
  "libp2p",
  "linked_hash_set",
  "log",
- "multihash 0.18.1",
+ "multihash 0.17.0",
  "multihash-codetable",
  "parity-scale-codec",
- "prost 0.12.3",
+ "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network",
- "sp-api",
+ "sc-network-types",
+ "sp-api 31.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2354138e44624d68245b9490c0d30f73bac7c00f218643ff03fc0dbd1536b98"
+checksum = "0f71eb27c36bb0cda3e67f1e0c4c45ced6672ad4c47148da6bc7fd729e99865a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9977,38 +10421,38 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d54ed880c04f6df650dcf4672d7d4a2d08b30e95c51f07b4a3be75eaa535082"
+checksum = "4190e69ccdf1b10c530e110345d67c6347aa0bc03fa56723103d834fb8ac907d"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d25ff00e77262342bd85a71de32170b136773f6a8cdd5641ce8b81fb4e16be"
+checksum = "a3256a5e3294dc363ddb17ac3040c33b9848269dd288eaf8ac6a2972f8a1d884"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "docify",
  "log",
  "memmap2 0.9.4",
@@ -10023,10 +10467,11 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-genesis-builder",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-genesis-builder 0.12.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -10038,16 +10483,16 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "sc-cli"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eade6864cba8ab29c4c7572c6a4a080c0423bc53cb48b00f70eef7d57d22abae"
+checksum = "397091529b095369e8b9342a0dcb732bf6ec672b4be9db76b5174951618f541a"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "chrono",
  "clap",
  "fdlimit",
@@ -10058,7 +10503,7 @@ dependencies = [
  "names",
  "parity-bip39",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -10077,45 +10522,45 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-panic-handler",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 36.0.0",
+ "sp-version 34.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f69c592a2cab8b5cb7860bf57c5084a590d2e0c5df9308f62ddb405ca4d97e"
+checksum = "cec1bf37389619d861680f7da315ac5a815e5cd924ec9a0adb86e4ba4aac7c99"
 dependencies = [
  "fnv",
  "futures",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-statement-store",
  "sp-storage",
- "sp-trie",
+ "sp-trie 34.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4e8c9db1025f0b17438f5db8937c53022b417593f30d4624b8b2e0d3300b9f"
+checksum = "ffe19e497ab77b89efa4e2b885af725d6ed59579ebe8df96b820f5b122c10da9"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10125,7 +10570,7 @@ dependencies = [
  "log",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-client-api",
  "sc-state-db",
  "schnellru",
@@ -10133,42 +10578,42 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a051ffa28788f7ec47e46d6236132126d5aa563469e6c852e87cfbe5069e0687"
+checksum = "0178e3ef8d317456e352466a9c5d3b6d9b5861a64b43c01ab62435e24fc68a51"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-identity",
  "log",
  "mockall",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-client-api",
+ "sc-network-types",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd537650a8f23d6775456a5a06e1cf27722fedc5515769983e18ef856a6aad3"
+checksum = "be48cd2fa20a6800595f7f49dbc929ad72348673c38eb7faa072cb8dfd7b47ce"
 dependencies = [
  "async-trait",
  "futures",
@@ -10179,26 +10624,26 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
+ "sp-inherents 31.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe6f127a27ea6ace8e4391ba847ccf21d3512499e1c5e7c300e7e5115642544"
+checksum = "08d58429c3660dfb86b9c0a1529dbc444f1ba8c8135812468497751d5b2567d6"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10208,15 +10653,15 @@ dependencies = [
  "num-rational",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-epochs",
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
@@ -10224,18 +10669,18 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-crypto-hashing",
- "sp-inherents",
+ "sp-inherents 31.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93183245d51eab164ab5513f5ad723964c38f293427d99066f8aed02ae715e1"
+checksum = "cd3bd3762945244a50e7e64aa9302405ba3d225a807872a4f99e8250e5ec4e60"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10243,39 +10688,40 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f0cdd776453ce7d73fdb548648bdfefdac6c497d198083222aa0d7636445ed"
+checksum = "0f0f27e60a0a3135c991e26883c4827f8bb3fa082ee84690544eea9040d0edf8"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-trait",
  "fnv",
  "futures",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
  "sc-network-gossip",
  "sc-network-sync",
+ "sc-network-types",
  "sc-utils",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10284,7 +10730,7 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10293,46 +10739,46 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8193f51766e9bf5a94f044333f4807918f7243eab404e9ff91b98ba268f2e9"
+checksum = "7db1d87a1107de282b3208e25370c1f54dcfc9f0c12bdea52fad127df4929c63"
 dependencies = [
  "futures",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-consensus-beefy",
  "sc-rpc",
  "serde",
  "sp-consensus-beefy",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2217e53886dbfd4749eaa2e671f8e59807a2fb711ffa0023b3dc5b30f5db458"
+checksum = "e7d878112bf0e7b267eb753e9a43432616dc190f85be921bc03d13c42a7c21bd"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d666c23af4325c6d2ca35bfe2874917f5dfdd94bfca165ad89b92191489e2d8"
+checksum = "4ba0980a68efdb28cba1a8051dd27d104258870f16287df9d576caf36add3ebc"
 dependencies = [
  "ahash 0.8.11",
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
@@ -10341,8 +10787,8 @@ dependencies = [
  "futures-timer",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
- "rand",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -10351,12 +10797,13 @@ dependencies = [
  "sc-network-common",
  "sc-network-gossip",
  "sc-network-sync",
+ "sc-network-types",
  "sc-telemetry",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10364,16 +10811,16 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ff3f1dc9c74563e559725736e07f4817e3429cdfd593e4a8c583d2c8da0894"
+checksum = "5c587c6b017281f2029a7901de1e2f6f85ee8b365e9d15b159a5c44450fc71f6"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10386,15 +10833,15 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80382f4da8a76c05c23b84d5c369bb5d617d499749171335e9b47599885fb202"
+checksum = "b755082e44000f02660697560c279d81cea4ea984d5a21eb27a2179c92912fbc"
 dependencies = [
  "async-trait",
  "futures",
@@ -10409,31 +10856,31 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b47b642a92adcabaeadb7d76bd1a02bcf5a93f2b649e81afe8b940107bbda"
+checksum = "5d0738d2e654f8cadb8b5b5f64c281654838202bf77641656b7fe2bd5346a25b"
 dependencies = [
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-executor-common",
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "sp-externalities",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-panic-handler",
  "sp-runtime-interface",
- "sp-trie",
- "sp-version",
+ "sp-trie 34.0.0",
+ "sp-version 34.0.0",
  "sp-wasm-interface",
  "tracing",
 ]
@@ -10474,7 +10921,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
@@ -10485,9 +10932,9 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061006dce0dcae3ece90d5d9f656ade507dd922931911d59deea823f28be54dd"
+checksum = "4bb38b9ee63b01ed966f67789684b517cdc7891c0ac30ddac0e039695a43ab03"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10498,19 +10945,19 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sc-keystore"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6477f27aa17ada189355325c16992d3e612d2fe276ecef9da1b36b6b297b3ac4"
+checksum = "8dbafebe46cb7a380d6a1a77c045af06de3cf92ffcb5bbbbb1567e3b0c94d688"
 dependencies = [
- "array-bytes 6.2.2",
- "parking_lot 0.12.1",
+ "array-bytes 6.2.3",
+ "parking_lot 0.12.2",
  "serde_json",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -10518,9 +10965,9 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e04fecf6e55e4597e473c87e8f3cea5a9963835af30a971203290d62bb2d03"
+checksum = "3c48f0897bac630c7f58e0e8f5b5930db18641ac5c0df6fcca0335520c1be74a"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -10528,35 +10975,36 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "libp2p-identity",
  "log",
  "mixnet",
  "multiaddr",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-client-api",
  "sc-network",
+ "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus",
  "sp-core",
  "sp-keystore",
  "sp-mixnet",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e68214c9245ee374a6c51fca3c00feddbe20a86451d92c76585a9cc9553425"
+checksum = "c94a6131f2c50126601a01d9b60a8df569aa8483cf6754e280b754a5e716a297"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-trait",
  "asynchronous-codec",
  "bytes",
+ "cid 0.9.0",
  "either",
  "fnv",
  "futures",
@@ -10564,58 +11012,44 @@ dependencies = [
  "ip_network",
  "libp2p",
  "linked_hash_set",
+ "litep2p",
  "log",
  "mockall",
+ "once_cell",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "partial_sort",
  "pin-project",
- "rand",
+ "prost 0.11.9",
+ "prost-build",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
+ "sc-network-types",
  "sc-utils",
+ "schnellru",
  "serde",
  "serde_json",
  "smallvec",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
  "tokio-stream",
  "unsigned-varint",
+ "void",
  "wasm-timer",
  "zeroize",
 ]
 
 [[package]]
-name = "sc-network-bitswap"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7cf01e661f39303737596859139fcdd31bd106a979fae0828f3e5b0decce89"
-dependencies = [
- "async-channel 1.9.0",
- "cid",
- "futures",
- "libp2p-identity",
- "log",
- "prost 0.12.3",
- "prost-build",
- "sc-client-api",
- "sc-network",
- "sp-blockchain",
- "sp-runtime",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
 name = "sc-network-common"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b1732616f6fd5bcdabd44eac79b466c2075f3f47ebf0cf2f6d52d790890736"
+checksum = "ae304be8447d6101c7d314932137ff2405db43bc7daf4b9c0c52341bdc9265ac"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -10624,16 +11058,17 @@ dependencies = [
  "parity-scale-codec",
  "prost-build",
  "sc-consensus",
+ "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb8b10666371dc53bd9e11dbb99e0763307203ecc70f4d9bb20169cf7ad69db"
+checksum = "ed5317c3a30c77978ef7cfb2655e4dae2f7ba82df1622b6b6e81c854c19ffb43"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -10643,41 +11078,42 @@ dependencies = [
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
+ "sc-network-types",
  "schnellru",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "sc-network-light"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be9c7b3d18d5ef3ed493be173e9cb00537585cd9b21bb4ebe24b9b555cf4fa4"
+checksum = "10a2b0e0c87d74704a758be2d3119bbbf652910b3de0d3074864531f2e1afd3c"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "futures",
- "libp2p-identity",
  "log",
  "parity-scale-codec",
- "prost 0.12.3",
+ "prost 0.12.6",
  "prost-build",
  "sc-client-api",
  "sc-network",
+ "sc-network-types",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network-sync"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8a240043ecd1c5ca54d1dfdc654878aed6b96fe7292c11dc9e8bc7c4884fb"
+checksum = "92d3a03c11fd5ed3c596a055d79596e6c0d7ea5166b627346e0381adde49dd50"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-trait",
  "fork-tree",
@@ -10687,12 +11123,13 @@ dependencies = [
  "log",
  "mockall",
  "parity-scale-codec",
- "prost 0.12.3",
+ "prost 0.12.6",
  "prost-build",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
  "sc-network-common",
+ "sc-network-types",
  "sc-utils",
  "schnellru",
  "smallvec",
@@ -10701,7 +11138,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10710,11 +11147,11 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1514ca1cc195842970b3a35b80cc14ed002296f3565c19d4659be44ca9255b8"
+checksum = "1f8586ce7e34e555021b574ec98c4d459cc46625f1d061a3ed8bea6a400e8648"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "futures",
  "libp2p",
  "log",
@@ -10722,19 +11159,35 @@ dependencies = [
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
+ "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
-name = "sc-offchain"
-version = "33.0.0"
+name = "sc-network-types"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f289809d0c3fd09474637bfe2dc732f41fb211d1241885194232c5d612a641"
+checksum = "a6b473a65393f65579019e4280cc116848439985c62724db8402bbfa7da462d1"
 dependencies = [
- "array-bytes 6.2.2",
+ "bs58 0.4.0",
+ "libp2p-identity",
+ "litep2p",
+ "multiaddr",
+ "multihash 0.17.0",
+ "rand 0.8.5",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-offchain"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb6f76c65abdabfadb497a5fe33733ec67af15221aa1c72686096aed75b28b8"
+dependencies = [
+ "array-bytes 6.2.3",
  "bytes",
  "fnv",
  "futures",
@@ -10746,19 +11199,20 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
- "parking_lot 0.12.1",
- "rand",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network",
  "sc-network-common",
+ "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "threadpool",
  "tracing",
 ]
@@ -10775,15 +11229,15 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d7b43d6ce2c57d90dab64a0eab4673158a7a240119fd3ae934ce95f8ad973f"
+checksum = "df3af3898afc9e63bfda6bbb75a20bb66a4b3de0bc077eb1b67d94b04f69b984"
 dependencies = [
  "futures",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -10793,24 +11247,24 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
  "sp-statement-store",
- "sp-version",
+ "sp-version 34.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82060f09f886f59fd19a77cc6668c209e883fc93511e9c441ef84adfea80f36"
+checksum = "2656a0da9ce809fb31dc0517b7e0a4185001785154b59cd9546566f1db8df346"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10822,8 +11276,8 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 36.0.0",
+ "sp-version 34.0.0",
  "thiserror",
 ]
 
@@ -10848,31 +11302,32 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad831d2524de44a89b1801e306fd9718dc5fadb26ea3e88f486faa29c6fdd710"
+checksum = "57f2b3d4ad7238f031c85395980f3b05026dba6f596e1e3600274fa9c30974e1"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "futures",
  "futures-util",
  "hex",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
- "rand",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc",
  "sc-transaction-pool-api",
  "sc-utils",
+ "schnellru",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 36.0.0",
+ "sp-version 34.0.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -10880,9 +11335,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff048cda961d13a0978bf6e75b1978c0fa886d2087133a4d2107a034afd27c8"
+checksum = "70d4e550aabcfba3a9e6a2c4e23dcfef362cb62bea2cfc3348879e327482ec72"
 dependencies = [
  "async-trait",
  "directories",
@@ -10892,9 +11347,9 @@ dependencies = [
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -10903,11 +11358,11 @@ dependencies = [
  "sc-informant",
  "sc-keystore",
  "sc-network",
- "sc-network-bitswap",
  "sc-network-common",
  "sc-network-light",
  "sc-network-sync",
  "sc-network-transactions",
+ "sc-network-types",
  "sc-rpc",
  "sc-rpc-server",
  "sc-rpc-spec-v2",
@@ -10920,20 +11375,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.40.0",
  "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie",
- "sp-version",
+ "sp-trie 34.0.0",
+ "sp-version 34.0.0",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -10951,7 +11406,7 @@ checksum = "7259ab2e8e2fa1e7a1c38dd8a88353f80e66369ef8b48d5f7098dbc18c67887f"
 dependencies = [
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sp-core",
 ]
 
@@ -10971,9 +11426,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75577af6d7128f3c0cd1dfa83f9ec056dbe4cdce297f1d257f2a1253134c6e9a"
+checksum = "910d78b0ea4778a639a9d1345d4e5ce27721ed0d717635aded1bb6c522044bb2"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10985,21 +11440,21 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-sysinfo"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a838bf3ba61e83c0f3be4a41ba7ed8c71d19c2adee6396046f78317006637b"
+checksum = "985818b31ecd4e04edadbf6124e2b71033551c08ff891bd9449fbddd2346ddf8"
 dependencies = [
  "derive_more",
  "futures",
  "libc",
  "log",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "regex",
  "sc-telemetry",
@@ -11007,23 +11462,24 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a5a306d8c75e61e8c59e18b92886f85db6b4102c4669240eca101954fec79e"
+checksum = "6a874600f40a5cef2e1482574f7665ed005f7c3b7594f9abddcb2e015651c4d9"
 dependencies = [
  "chrono",
  "futures",
  "libp2p",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "pin-project",
- "rand",
+ "rand 0.8.5",
+ "sc-network",
  "sc-utils",
  "serde",
  "serde_json",
@@ -11033,9 +11489,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584e4f81defe03776909ce283429c9cd3d80fea6b2f3a303dc2bdf913e11d9e8"
+checksum = "8c7513573600566bcc7a41153c6a99b628e800acd65bc124c3ac595322324021"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -11044,22 +11500,22 @@ dependencies = [
  "libc",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "regex",
  "rustc-hash",
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-tracing",
  "thiserror",
  "tracing",
- "tracing-log",
- "tracing-subscriber",
+ "tracing-log 0.1.4",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -11071,14 +11527,14 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54754bf43dede417a8e64a0d6a46bf2bbed47ff050c1f81c8a575f9b94416886"
+checksum = "18f865b689f7f732de5c6129cbdb793d7c71a88ef0d1636d8b843e590d5d766a"
 dependencies = [
  "async-trait",
  "futures",
@@ -11086,16 +11542,16 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sc-client-api",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -11104,9 +11560,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b563c7257ab650b2639d623da13d1a50a5a6c4ec582bc92e118c73d072bcd4"
+checksum = "618532cf1e4afbc3a3f9046bfb4aaceba46fa9888ec9d1d12e9fe5448aa7ee82"
 dependencies = [
  "async-trait",
  "futures",
@@ -11115,7 +11571,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
@@ -11130,9 +11586,32 @@ dependencies = [
  "futures-timer",
  "lazy_static",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "prometheus",
  "sp-arithmetic",
+]
+
+[[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12ebca36cec2a3f983c46295b282b35e5f8496346fb859a8776dad5389e5389"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
 ]
 
 [[package]]
@@ -11162,6 +11641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11172,9 +11657,9 @@ dependencies = [
 
 [[package]]
 name = "schnellru"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772575a524feeb803e5b0fcbc6dd9f367e579488197c94c6e4023aad2305774d"
+checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
 dependencies = [
  "ahash 0.8.11",
  "cfg-if",
@@ -11239,6 +11724,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sctp-proto"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f64cef148d3295c730c3cb340b0b252a4d570b1c7d4bf0808f88540b0a888bc"
+dependencies = [
+ "bytes",
+ "crc",
+ "fxhash",
+ "log",
+ "rand 0.8.5",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11291,11 +11791,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -11304,9 +11804,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -11323,9 +11823,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
@@ -11338,9 +11838,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
@@ -11356,20 +11856,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -11378,9 +11878,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -11409,6 +11909,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+ "sha1-asm",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11417,6 +11929,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -11470,12 +11991,18 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
@@ -11498,6 +12025,15 @@ dependencies = [
  "num-traits",
  "paste",
  "wide",
+]
+
+[[package]]
+name = "simple-dns"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae9a3fcdadafb6d97f4c0e007e4247b114ee0f119f650c3cbf3a8b3a1479694"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -11529,14 +12065,14 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0e4ae8d02b43620ca7f567ca94fff494d85aecc73ffebda6c8fa19545b1673"
+checksum = "7bb6f55c7308986f519ce3d554f832774e6212b14774e72313a0c1a3591adf5a"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
@@ -11551,9 +12087,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smol"
@@ -11584,7 +12120,7 @@ dependencies = [
  "base64 0.21.7",
  "bip39",
  "blake2-rfc",
- "bs58 0.5.0",
+ "bs58 0.5.1",
  "chacha20",
  "crossbeam-queue",
  "derive_more",
@@ -11594,7 +12130,7 @@ dependencies = [
  "fnv",
  "futures-lite 1.13.0",
  "futures-util",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "hmac 0.12.1",
  "itertools 0.11.0",
@@ -11608,7 +12144,7 @@ dependencies = [
  "pbkdf2",
  "pin-project",
  "poly1305",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "ruzstd",
  "schnorrkel 0.10.2",
@@ -11643,15 +12179,15 @@ dependencies = [
  "futures-channel",
  "futures-lite 1.13.0",
  "futures-util",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "itertools 0.11.0",
  "log",
  "lru 0.11.1",
  "no-std-net",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
@@ -11697,9 +12233,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -11718,8 +12254,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
- "sha-1",
+ "rand 0.8.5",
+ "sha-1 0.9.8",
 ]
 
 [[package]]
@@ -11732,16 +12268,39 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro",
+ "sp-api-proc-macro 18.0.0",
  "sp-core",
  "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime",
+ "sp-runtime 35.0.0",
  "sp-runtime-interface",
- "sp-state-machine",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 33.0.0",
+ "sp-version 33.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-api"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b500647cfe266d58781f44af9b13c3bd57fb3be08642f2a9f13e024cc5e22359"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro 19.0.0",
+ "sp-core",
+ "sp-externalities",
+ "sp-metadata-ir",
+ "sp-runtime 36.0.0",
+ "sp-runtime-interface",
+ "sp-state-machine 0.40.0",
+ "sp-std",
+ "sp-trie 34.0.0",
+ "sp-version 34.0.0",
  "thiserror",
 ]
 
@@ -11757,7 +12316,22 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "sp-api-proc-macro"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213a4bec1b18bd0750e7b81d11d8276c24f68b53cde83950b00b178ecc9ab24a"
+dependencies = [
+ "Inflector",
+ "blake2 0.10.6",
+ "expander 2.1.0",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -11770,7 +12344,21 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
+ "sp-io 34.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57541120624a76379cc993cbb85064a5148957a92da032567e54bce7977f51fc"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io 35.0.0",
  "sp-std",
 ]
 
@@ -11792,143 +12380,143 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5700c6f51afc80af2dd2b39973183d7527e8b5be390fa125d777f948db0e88"
+checksum = "6d8494eafd70194198b7fd82446da59380c7346bedf68e83dfbdb5f338395437"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-block-builder"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "466eaa1fe1745e9456a5e5afc033b67a52211463a137ea3551bff36b4d72ce03"
+checksum = "51cf3d8fb96de98aecdd32cdd4a735af4d84fae274314f411f95c89d4dff6ad3"
 dependencies = [
- "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed0dc760fde2b2cd07ca9428e3d6b7ecc02bbd00a5dc32b7f829c80889b152b"
+checksum = "488d3cc94c345ce55d1890239bb256f4418f9566e29b7b90f01817bc7b553a08"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "schnellru",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19910bc7cd10336a1b13611df1212bce5cabbcfcd92a9394e23476498aa360c7"
+checksum = "3f400a20113301fa91094c210b9b9b63f066cee55f22517768eaadf3519124d8"
 dependencies = [
  "async-trait",
  "futures",
  "log",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67647dc44d2f47f8b96a56f30a896926485e55a8209cfe916cf8d08a6d488f03"
+checksum = "c8904da70720b26f207b6ae1d140cac4f5b10b94bce535e08ee0df08f3a27a84"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3500dd1ceb99ca5e6f399d37c4e42f22fcbb6505e07378791ebe57eec6a1960"
+checksum = "75f99229c382c3f849160da42c897321fd6b82fe685bc0c4ba4afdd51b818bd1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160ad989b247b55fdc2acd8baa7d5a0b9daca5ad0d4fac6e94ee119ed0fdf164"
+checksum = "f5eb094064dd8f1ff03bd92c843c5f979c1b18e955afb5c0ad98f9c781225e12"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "strum 0.26.2",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffc3f88b33c2a8c14f4d05a3c69c5fc7b02cdd3300993a22d6d2175d35447f6"
+checksum = "a6f4d90b65fd82e77c3b8c382c3a9e669bba5ccfb5402a945cde88984c98681b"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dcae1dac6908d80bceaff4f311bc694c3b9c0d3ac6e74128ed4e3a29e9e31f"
+checksum = "60823551c6987e2f5e1dda772140a09850e866e704757662795b8e7cacf9b228"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11942,11 +12530,11 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2dac7e47c7ddbb61efe196d5cce99f6ea88926c961fa39909bfeae46fc5a7b"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "bounded-collections",
- "bs58 0.5.0",
+ "bs58 0.5.1",
  "dyn-clonable",
  "ed25519-zebra 3.1.0",
  "futures",
@@ -11960,10 +12548,10 @@ dependencies = [
  "merlin",
  "parity-bip39",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "paste",
  "primitive-types",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
@@ -12005,7 +12593,7 @@ checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -12015,7 +12603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722cbecdbf5b94578137dbd07feb51e95f7de221be0c1ff4dcfe0bb4cd986929"
 dependencies = [
  "kvdb",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
 ]
 
 [[package]]
@@ -12026,7 +12614,7 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -12047,8 +12635,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8a812b56fb4ed6a598ad7b43be127702aba1f7351ad4916f5bab995054cdc5"
 dependencies = [
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-genesis-builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7605a8ed2c06d348c26055b7907c3d2d62f984666e9025b57df4895f865f5901"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde_json",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -12061,7 +12662,21 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170537049d57fc645637e4586fe98a3291392b2ecfd7988ea31639cf43470b42"
+dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
@@ -12072,7 +12687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c44ed47247b6eee76ff703f9fa9f04f99c4104ac1faf629e6d1128e09066b57b"
 dependencies = [
  "bytes",
- "ed25519-dalek",
+ "ed25519-dalek 2.1.1",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
@@ -12084,22 +12699,49 @@ dependencies = [
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
- "sp-state-machine",
+ "sp-state-machine 0.39.0",
  "sp-std",
  "sp-tracing",
- "sp-trie",
+ "sp-trie 33.0.0",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "sp-io"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b64ab18a0e29def6511139a8c45a59c14a846105aab6f9cc653523bd3b81f55"
+dependencies = [
+ "bytes",
+ "ed25519-dalek 2.1.1",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "polkavm-derive",
+ "rustversion",
+ "secp256k1",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine 0.40.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie 34.0.0",
  "tracing",
  "tracing-core",
 ]
 
 [[package]]
 name = "sp-keyring"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089da5d08c4a6b4a36de664de287f4a391ac338e351a923b79aedfc46162f201"
+checksum = "33d2c495248bd141fe04ec639785c874949b2c552c00ea4afc4c183c654466ce"
 dependencies = [
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "strum 0.26.2",
 ]
 
@@ -12110,7 +12752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6c7a7abd860a5211a356cf9d5fcabf0eb37d997985e5d722b6b33dcc815528"
 dependencies = [
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "sp-core",
  "sp-externalities",
 ]
@@ -12138,57 +12780,57 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ba1e6ceede3aa5e36ee161dc02f1b294a659823887cefc4f0f2fce589e3c11"
+checksum = "2242e7a802822109e007c3d6ee79640f8dc3abee7139d34ce029c7478361be8c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
 ]
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8abf5586785c20bb4bdbc81243877d5bb2bdf6dff6a03c101b6a3a875bc9278"
+checksum = "dedd59967d2f759bec2be705840d170a5dbf38866acaedffe7c813e7547325bf"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "sp-debug-derive",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-npos-elections"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae4f90a3a36f052f4f9aa6f6ab1d59cf6f895f3a939f40dbe1f3e14907a2e31"
+checksum = "8e52344b6fd91289a87c3fca03e5147df178167b150e1a10b82243434f43e134"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-offchain"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50efea44dfc8e40c59e9f9099c6a4f64dc750ad224fd8dbf9aec12fc857fa145"
+checksum = "2cbbd2096fda34c2f6f9f268c808ca280c08565e759309ea24f17dcd0808097b"
 dependencies = [
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -12226,14 +12868,39 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto",
+ "sp-application-crypto 34.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
+ "sp-io 34.0.0",
+ "sp-std",
+ "sp-weights",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6b85cb874b78ebb17307a910fc27edf259a0455ac5155d87eaed8754c037e07"
+dependencies = [
+ "docify",
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "simple-mermaid",
+ "sp-application-crypto 35.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io 35.0.0",
  "sp-std",
  "sp-weights",
 ]
@@ -12269,22 +12936,22 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "sp-session"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d66f0f2f00e4c520deae07eeab7acf04c1a41dd875c7a4689e4e4302fb89925"
+checksum = "9c558f85486882433adcfdfe05c5e82972a7be1a6d7fa68a6213b70ec1d86068"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
 ]
 
 [[package]]
@@ -12298,7 +12965,21 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-staking"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd38abe12a12b0c24d318011ec3cd3280f8d828666994695a6c0652f38662dbf"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -12310,38 +12991,59 @@ dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
- "rand",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
  "smallvec",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-trie",
+ "sp-trie 33.0.0",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.28.0",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18084cb996c27d5d99a88750e0a8eb4af6870a40df97872a5923e6d293d95fb9"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
+ "smallvec",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-trie 34.0.0",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
 name = "sp-statement-store"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e22e2d355461e02aa8325a819d24403fb7232a828bf1e21ad8982fde3f0dc0e"
+checksum = "c7ac525ad4b3533aebdd68ae097d0a55887b6499b565c5a592f6c18372a40caf"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
- "ed25519-dalek",
+ "ed25519-dalek 2.1.1",
  "hkdf",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-runtime-interface",
  "thiserror",
  "x25519-dalek 2.0.1",
@@ -12368,14 +13070,14 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d3965ef60cc066fcc01dbcb7837404f40de8ac58f1115e3a3a1d6550575ff6"
+checksum = "bdb7768c895643e315f9bcfacdd61e283b78c862d976fd081a508cf7239c8643"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
@@ -12388,32 +13090,32 @@ dependencies = [
  "parity-scale-codec",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bddae32e6935eedda993b7371b79e69af901a277e11be2bbd6d9bc7643b49cb"
+checksum = "207cb372504cf86237fa63953a0aa40d7596d1c9cf21175a56346ed1744eb8fe"
 dependencies = [
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726f90279766e231ad86f884e5f07d9331852a59d739f27c5f5e28bee0fc6da5"
+checksum = "1141f46e088898986a59c8aae4a91c8d8c04da22a38986a8bdfcb2446889ee5a"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
@@ -12428,15 +13130,39 @@ dependencies = [
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
- "parking_lot 0.12.1",
- "rand",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
  "sp-core",
  "sp-externalities",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.28.0",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-trie"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87727eced997f14d0f79e3a5186a80e38a9de87f6e9dc0baea5ebf8b7f9d8b66"
+dependencies = [
+ "ahash 0.8.11",
+ "hash-db",
+ "lazy_static",
+ "memory-db",
+ "nohash-hasher",
+ "parity-scale-codec",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
+ "scale-info",
+ "schnellru",
+ "sp-core",
+ "sp-externalities",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
  "trie-root",
 ]
 
@@ -12452,7 +13178,25 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "sp-std",
+ "sp-version-proc-macro",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-version"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8e3856686aa2719b1c05af07ba7e6021d844944472f246f3b5f1c585be04cd"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "parity-wasm",
+ "scale-info",
+ "serde",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -12467,7 +13211,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -12511,17 +13255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "spinners"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ef947f358b9c238923f764c72a4a9d42f2d637c46e059dbd319d6e7cfb4f82"
-dependencies = [
- "lazy_static",
- "maplit",
- "strum 0.24.1",
-]
-
-[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12542,9 +13275,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.46.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1114ee5900b8569bbc8b1a014a942f937b752af4b44f4607430b5f86cedaac0"
+checksum = "4743ce898933fbff7bbf414f497c459a782d496269644b3d650a398ae6a487ba"
 dependencies = [
  "Inflector",
  "num-format",
@@ -12563,26 +13296,26 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1383aa763f2cea1a816761948bfc1245040740d418c6b77d36fd4f259b944d84"
+checksum = "4efd2f6285b97c1797f8451afb9834a90bd7b90712e6d1a3df8f68f9e7357ea6"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "staging-xcm"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aded0292274ad473250c22ed3deaf2d9ed47d15786d700e9e83ab7c1cad2ad44"
+checksum = "5090e0801a8aeb28ff88cc6e0ca0bad399cc58eed11ec70c517fcb316bd3151b"
 dependencies = [
- "array-bytes 6.2.2",
+ "array-bytes 6.2.3",
  "bounded-collections",
  "derivative",
  "environmental",
@@ -12597,12 +13330,12 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0681b0a478c2f5e1f1ae9b7e8e4970d79ec8ef94f4efebc011ea335822bc264e"
+checksum = "a5ccd51b148ec7c72f98cd315952595af353c103f4ad76cb600a85b8ee60adf4"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-transaction-payment",
@@ -12610,8 +13343,8 @@ dependencies = [
  "polkadot-parachain-primitives",
  "scale-info",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
  "staging-xcm",
@@ -12620,21 +13353,21 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb518e82e9982c90c32b66263642385fc186c76f329766884d3360b65e84dd46"
+checksum = "39025611744d726ee1cb6661c09b13cd41525ca791f4fba45d68a00db9582063"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
  "staging-xcm",
@@ -12675,6 +13408,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "str0m"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee48572247f422dcbe68630c973f8296fbd5157119cd36a3223e48bf83d47727"
+dependencies = [
+ "combine",
+ "crc",
+ "hmac 0.12.1",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "rand 0.8.5",
+ "sctp-proto",
+ "serde",
+ "sha-1 0.10.1",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "strobe-rs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12689,24 +13442,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum"
@@ -12732,19 +13476,6 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.58",
-]
-
-[[package]]
-name = "strum_macros"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
@@ -12753,7 +13484,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -12777,9 +13508,9 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949d14f7bb2a53b77985bd17a8eb2e9edf8d5bbf4409e9acb036fa3bf7310d8f"
+checksum = "d19975c2965833aed97064cd34975ed5bc0390e4436c84b381874c8abce43712"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -12788,11 +13519,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -12809,24 +13540,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-rpc-client"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812076602836d6d90242c431729814c790c49685d142f47ec41f3b897a5fb6ad"
-dependencies = [
- "async-trait",
- "jsonrpsee",
- "log",
- "sc-rpc-api",
- "serde",
- "sp-runtime",
-]
-
-[[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da2e823fb02fbd5c77d6949cde60ff3e320c100278818000b39e9f0a8c8c428"
+checksum = "538029eeb26c9ab3f5f8677d696336f92ee536918f4e7ba7fcad1d08ad31ca6b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12834,28 +13551,37 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
- "trie-db",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
+ "sp-trie 34.0.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "21.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a7c3e61041eaa76a89ded469f84d243fb34557ba4ee1e60335e65c8b5540c9"
+checksum = "6567b61eca9459dbe71385caef9f6eab826abbd4a0743abf27034d96d34b9062"
 dependencies = [
+ "array-bytes 6.2.3",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
+ "sc-executor",
+ "sp-core",
+ "sp-io 35.0.0",
  "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "sp-version 34.0.0",
  "strum 0.26.2",
  "tempfile",
- "toml 0.8.10",
+ "toml 0.8.13",
  "walkdir",
  "wasm-opt",
 ]
@@ -12891,9 +13617,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12952,8 +13678,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
- "rustix 0.38.31",
+ "fastrand 2.1.0",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -12972,7 +13698,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.31",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -12984,9 +13710,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
@@ -13008,18 +13734,18 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -13083,9 +13809,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -13104,9 +13830,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -13147,10 +13873,10 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
- "pin-project-lite 0.2.13",
+ "parking_lot 0.12.2",
+ "pin-project-lite 0.2.14",
  "signal-hook-registry",
- "socket2 0.5.6",
+ "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -13163,18 +13889,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand",
- "tokio",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -13183,7 +13898,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -13193,36 +13908,50 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.10"
+name = "tokio-tungstenite"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -13236,21 +13965,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.6",
+ "toml_edit 0.22.13",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -13261,18 +13990,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.5",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -13283,22 +14001,22 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow 0.6.8",
 ]
 
 [[package]]
@@ -13310,7 +14028,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -13322,14 +14040,14 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-range-header",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "tower-layer",
  "tower-service",
 ]
@@ -13353,7 +14071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -13366,7 +14084,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -13391,9 +14109,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48057e9b12f413d8d104aeb84d6efad65e8bd325acbfa91f7f97724bcf1dd2ed"
+checksum = "d037e38c3da801f670c99e555882a8009c40a8a473815e6a4ea72a8e2887c0c4"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -13411,7 +14129,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -13419,6 +14137,17 @@ name = "tracing-log"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -13444,8 +14173,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
- "parking_lot 0.11.2",
+ "matchers 0.0.1",
  "regex",
  "serde",
  "serde_json",
@@ -13454,8 +14182,27 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.4",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers 0.1.0",
+ "nu-ansi-term",
+ "once_cell",
+ "parking_lot 0.12.2",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -13466,6 +14213,18 @@ checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c992b4f40c234a074d48a757efeabb1a6be88af84c0c23f7ca158950cb0ae7f"
+dependencies = [
+ "hash-db",
  "log",
  "rustc-hex",
  "smallvec",
@@ -13489,16 +14248,41 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "futures-channel",
  "futures-io",
  "futures-util",
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "socket2 0.4.10",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner 0.6.0",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "smallvec",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -13517,13 +14301,34 @@ dependencies = [
  "ipconfig",
  "lazy_static",
  "lru-cache",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "resolv-conf",
  "smallvec",
  "thiserror",
  "tokio",
  "tracing",
- "trust-dns-proto",
+ "trust-dns-proto 0.22.0",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trust-dns-proto 0.23.2",
 ]
 
 [[package]]
@@ -13533,47 +14338,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "try-runtime-cli"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45904e10377e9973238ae9e52bd0fbbb0bba5d7be9198458ba9d3fe0a4173ed"
-dependencies = [
- "async-trait",
- "clap",
- "frame-remote-externalities",
- "frame-try-runtime",
- "hex",
- "log",
- "parity-scale-codec",
- "sc-cli",
- "sc-executor",
- "serde",
- "serde_json",
- "sp-api",
- "sp-consensus-aura",
- "sp-consensus-babe",
- "sp-core",
- "sp-debug-derive",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-rpc",
- "sp-runtime",
- "sp-state-machine",
- "sp-timestamp",
- "sp-transaction-storage-proof",
- "sp-version",
- "sp-weights",
- "substrate-rpc-client",
- "zstd 0.12.4",
-]
-
-[[package]]
 name = "tt-call"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.21.12",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "twox-hash"
@@ -13583,7 +14371,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -13634,9 +14422,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
@@ -13664,6 +14452,7 @@ dependencies = [
  "bytes",
  "futures-io",
  "futures-util",
+ "tokio-util",
 ]
 
 [[package]]
@@ -13688,6 +14477,12 @@ dependencies = [
  "idna 0.5.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -13734,7 +14529,7 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
@@ -13745,9 +14540,9 @@ dependencies = [
 
 [[package]]
 name = "waker-fn"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -13810,7 +14605,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
  "wasm-bindgen-shared",
 ]
 
@@ -13844,7 +14639,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -13866,9 +14661,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt"
-version = "0.116.0"
+version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc942673e7684671f0c5708fc18993569d184265fd5223bb51fc8e5b9b6cfd52"
+checksum = "2fd87a4c135535ffed86123b6fb0f0a5a0bc89e50416c942c5f0662c645f679c"
 dependencies = [
  "anyhow",
  "libc",
@@ -13962,9 +14757,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.100.1"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
 ]
@@ -14144,7 +14939,7 @@ dependencies = [
  "memfd",
  "memoffset",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rustix 0.36.17",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -14195,17 +14990,17 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d7d64eabcbf938ac7978ebc0e3385caedacb2967ee6e2a9b9e1b69a2590498"
+checksum = "13acc56783ce7fca15017890034ed043cb91de2caab28a91a5b4209a1214eed4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -14271,27 +15066,27 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 34.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -14302,16 +15097,16 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e49413f666c93595698e3e3283fb05d7d5e0a522ecb6d4c6220d959691d479"
+checksum = "0eb9a91bc8d5ec0a260735651284eb4420c1a2de62b2430cf16c723186eabd28"
 dependencies = [
- "frame-support",
+ "frame-support 33.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-weights",
  "staging-xcm",
  "staging-xcm-builder",
@@ -14326,14 +15121,14 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.31",
+ "rustix 0.38.34",
 ]
 
 [[package]]
 name = "wide"
-version = "0.7.15"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89beec544f246e679fc25490e3f8e08003bc4bf612068f325120dad4cea02c1c"
+checksum = "21e005a4cc35784183a9e39cb22e9a9c46353ef6a7f113fd8d36ddc58c15ef3c"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -14341,9 +15136,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
@@ -14363,11 +15158,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14401,7 +15196,22 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -14428,7 +15238,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -14463,17 +15273,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -14490,9 +15301,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -14508,9 +15319,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -14526,9 +15337,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -14544,9 +15361,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -14562,9 +15379,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -14580,9 +15397,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -14598,9 +15415,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -14613,9 +15430,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
 ]
@@ -14681,16 +15498,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "xcm-fee-payment-runtime-api"
-version = "0.1.0"
+name = "x509-parser"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9c9513e249ed6d355d0243748c70cb0d7ca81d0604707f334fd481d54e8264"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
 dependencies = [
- "frame-support",
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "xcm-fee-payment-runtime-api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92be74937c8012c951c667bb0fb016634ab4adeac46f8106aef331f836059167"
+dependencies = [
+ "frame-support 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
  "staging-xcm",
@@ -14698,14 +15532,14 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4717a97970a9cda70d7db53cf50d2615c2f6f6b7c857445325b4a39ea7aa2cd"
+checksum = "fd9498be6aff2d380250c4b155faaebe4a83da181a00402dedac6c8166850198"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -14717,8 +15551,8 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.1",
- "rand",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -14733,22 +15567,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -14768,7 +15602,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -14811,9 +15645,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.10+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ frame-system-benchmarking = { version = "33.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "31.0.0", default-features = false }
 frame-try-runtime = { version = "0.39.0", default-features = false }
 pallet-aura = { version = "32.0.0", default-features = false }
-pallet-assets = { version = "33.0.0", default-features = false }
+pallet-assets = { version = "34.0.0", default-features = false }
 pallet-authorship = { version = "33.0.0", default-features = false }
 pallet-balances = { version = "34.0.0", default-features = false }
 pallet-message-queue = { version = "36.0.0", default-features = false }
-pallet-nfts = { version = "26.0.0", default-features = false }
-pallet-nfts-runtime-api = { version = "18.0.0", default-features = false }
-pallet-nft-fractionalization = { version = "14.0.0", default-features = false }
+pallet-nfts = { version = "27.0.0", default-features = false }
+pallet-nfts-runtime-api = { version = "19.0.0", default-features = false }
+pallet-nft-fractionalization = { version = "15.0.0", default-features = false }
 pallet-session = { version = "33.0.0", default-features = false }
 pallet-sudo = { version = "33.0.0", default-features = false }
 pallet-timestamp = { version = "32.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/r0gue-io/base-parachain"
 
 [workspace]
 members = [
-	"node",
-	"runtime",
+    "node",
+    "runtime",
 ]
 resolver = "2"
 
@@ -30,97 +30,99 @@ smallvec = "1.11.2"
 
 # Build
 substrate-build-script-utils = "11.0.0"
-substrate-wasm-builder = "21.0.0"
+substrate-wasm-builder = "22.0.1"
+docify = "0.2.8"
 
 # Local
 parachain-template-runtime = { path = "./runtime" }
 
 # Substrate
-frame-benchmarking = { version = "32.0.0", default-features = false }
-frame-benchmarking-cli = "36.0.0"
-frame-executive = { version = "32.0.0", default-features = false }
-frame-support = { version = "32.0.0", default-features = false }
-frame-system = { version = "32.0.0", default-features = false }
-frame-system-benchmarking = { version = "32.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "30.0.0", default-features = false }
-frame-try-runtime = { version = "0.38.0", default-features = false }
+frame-benchmarking = { version = "33.0.0", default-features = false }
+frame-benchmarking-cli = "37.0.0"
+frame-executive = { version = "33.0.0", default-features = false }
+frame-metadata-hash-extension = { version = "0.2.0", default-features = false }
+frame-support = { version = "33.0.0", default-features = false }
+frame-system = { version = "33.0.0", default-features = false }
+frame-system-benchmarking = { version = "33.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "31.0.0", default-features = false }
+frame-try-runtime = { version = "0.39.0", default-features = false }
+pallet-aura = { version = "32.0.0", default-features = false }
 pallet-assets = { version = "33.0.0", default-features = false }
-pallet-aura = { version = "31.0.0", default-features = false }
-pallet-authorship = { version = "32.0.0", default-features = false }
-pallet-balances = { version = "33.0.0", default-features = false }
-pallet-message-queue = { version = "35.0.0", default-features = false }
+pallet-authorship = { version = "33.0.0", default-features = false }
+pallet-balances = { version = "34.0.0", default-features = false }
+pallet-message-queue = { version = "36.0.0", default-features = false }
 pallet-nfts = { version = "26.0.0", default-features = false }
 pallet-nfts-runtime-api = { version = "18.0.0", default-features = false }
 pallet-nft-fractionalization = { version = "14.0.0", default-features = false }
-pallet-session = { version = "32.0.0", default-features = false }
-pallet-sudo = { version = "32.0.0", default-features = false }
-pallet-timestamp = { version = "31.0.0", default-features = false }
-pallet-transaction-payment = { version = "32.0.0", default-features = false }
-pallet-transaction-payment-rpc = "34.0.0"
-pallet-transaction-payment-rpc-runtime-api = { version = "32.0.0", default-features = false }
-sc-basic-authorship = "0.38.0"
-sc-chain-spec = "31.0.0"
-sc-cli = "0.40.0"
-sc-client-api = "32.0.0"
-sc-offchain = "33.0.0"
-sc-consensus = "0.37.0"
-sc-executor = "0.36.0"
-sc-network = "0.38.0"
-sc-network-sync = "0.37.0"
-sc-rpc = "33.0.0"
-sc-service = "0.39.0"
-sc-sysinfo = "31.0.0"
-sc-telemetry = "18.0.0"
-sc-tracing = "32.0.0"
-sc-transaction-pool = "32.0.0"
-sc-transaction-pool-api = "32.0.0"
-sp-api = { version = "30.0.0", default-features = false }
-sp-block-builder = { version = "30.0.0", default-features = false }
-sp-blockchain = "32.0.0"
-sp-consensus-aura = { version = "0.36.0", default-features = false }
+pallet-session = { version = "33.0.0", default-features = false }
+pallet-sudo = { version = "33.0.0", default-features = false }
+pallet-timestamp = { version = "32.0.0", default-features = false }
+pallet-transaction-payment = { version = "33.0.0", default-features = false }
+pallet-transaction-payment-rpc = "35.0.0"
+pallet-transaction-payment-rpc-runtime-api = { version = "33.0.0", default-features = false }
+sc-basic-authorship = "0.39.0"
+sc-chain-spec = "32.0.0"
+sc-cli = "0.41.0"
+sc-client-api = "33.0.0"
+sc-offchain = "34.0.0"
+sc-consensus = "0.38.0"
+sc-executor = "0.37.0"
+sc-network = "0.39.0"
+sc-network-sync = "0.38.0"
+sc-rpc = "34.0.0"
+sc-service = "0.40.0"
+sc-sysinfo = "32.0.0"
+sc-telemetry = "19.0.0"
+sc-tracing = "33.0.0"
+sc-transaction-pool = "33.0.0"
+sc-transaction-pool-api = "33.0.0"
+sp-api = { version = "31.0.0", default-features = false }
+sp-block-builder = { version = "31.0.0", default-features = false }
+sp-blockchain = "33.0.0"
+sp-consensus-aura = { version = "0.37.0", default-features = false }
 sp-core = { version = "32.0.0", default-features = false }
-sp-io = { version = "34.0.0", default-features = false }
-sp-genesis-builder = { version = "0.11.0", default-features = false }
-sp-inherents = { version = "30.0.0", default-features = false }
+sp-io = { version = "35.0.0", default-features = false }
+sp-genesis-builder = { version = "0.12.0", default-features = false }
+sp-inherents = { version = "31.0.0", default-features = false }
 sp-keystore = "0.38.0"
-sp-offchain = { version = "30.0.0", default-features = false }
-sp-runtime = { version = "35.0.0", default-features = false }
-sp-session = { version = "31.0.0", default-features = false }
+sp-offchain = { version = "31.0.0", default-features = false }
+sp-runtime = { version = "36.0.0", default-features = false }
+sp-session = { version = "32.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
-sp-timestamp = "30.0.0"
-sp-transaction-pool = { version = "30.0.0", default-features = false }
-sp-version = { version = "33.0.0", default-features = false }
-substrate-frame-rpc-system = "32.0.0"
+sp-timestamp = "31.0.0"
+sp-transaction-pool = { version = "31.0.0", default-features = false }
+sp-version = { version = "34.0.0", default-features = false }
+substrate-frame-rpc-system = "33.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 
 # Polkadot
-pallet-xcm = { version = "11.0.0", default-features = false }
-polkadot-cli = "11.0.0"
-polkadot-parachain-primitives = { version = "10.0.0", default-features = false }
-polkadot-primitives = "11.0.0"
-polkadot-runtime-common = { version = "11.0.0", default-features = false }
-xcm = { version = "11.0.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "11.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "11.0.0", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { version = "12.0.0", default-features = false }
+polkadot-cli = "12.0.0"
+polkadot-parachain-primitives = { version = "11.0.0", default-features = false }
+polkadot-primitives = "12.0.0"
+polkadot-runtime-common = { version = "12.0.0", default-features = false }
+xcm = { version = "12.0.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "12.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "12.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = "0.11.0"
-cumulus-client-collator = "0.11.0"
-cumulus-client-consensus-aura = "0.11.0"
-cumulus-client-consensus-common = "0.11.0"
-cumulus-client-consensus-proposer = "0.11.0"
-cumulus-client-service = "0.11.0"
-cumulus-pallet-aura-ext = { version = "0.11.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.11.0", default-features = false, features = ["parameterized-consensus-hook"] }
-cumulus-pallet-session-benchmarking = { version = "13.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.11.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.11.0", default-features = false }
-cumulus-primitives-aura = { version = "0.11.0", default-features = false }
-cumulus-primitives-core = { version = "0.11.0", default-features = false }
-cumulus-primitives-parachain-inherent = "0.11.0"
-cumulus-primitives-storage-weight-reclaim = { version = "2.0.0", default-features = false }
-cumulus-primitives-utility = { version = "0.11.0", default-features = false }
-cumulus-relay-chain-interface = "0.11.0"
-pallet-collator-selection = { version = "13.0.1", default-features = false }
-parachains-common = { version = "11.0.0", default-features = false }
-parachain-info = { version = "0.11.0", package = "staging-parachain-info", default-features = false }
+cumulus-client-cli = "0.12.0"
+cumulus-client-collator = "0.12.0"
+cumulus-client-consensus-aura = "0.12.0"
+cumulus-client-consensus-common = "0.12.0"
+cumulus-client-consensus-proposer = "0.12.0"
+cumulus-client-service = "0.12.0"
+cumulus-pallet-aura-ext = { version = "0.12.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.12.0", default-features = false, features = ["parameterized-consensus-hook"] }
+cumulus-pallet-session-benchmarking = { version = "14.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.12.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.12.0", default-features = false }
+cumulus-primitives-aura = { version = "0.12.0", default-features = false }
+cumulus-primitives-core = { version = "0.12.0", default-features = false }
+cumulus-primitives-parachain-inherent = "0.12.0"
+cumulus-primitives-storage-weight-reclaim = { version = "3.0.0", default-features = false }
+cumulus-primitives-utility = { version = "0.12.0", default-features = false }
+cumulus-relay-chain-interface = "0.12.0"
+pallet-collator-selection = { version = "14.0.0", default-features = false }
+parachains-common = { version = "12.0.0", default-features = false }
+parachain-info = { version = "0.12.0", package = "staging-parachain-info", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -60,7 +60,7 @@ substrate-frame-rpc-system.workspace = true
 substrate-prometheus-endpoint.workspace = true
 
 # Polkadot
-polkadot-cli.workspace = true
+polkadot-cli = { workspace = true, features = ["rococo-native"] }
 polkadot-primitives.workspace = true
 xcm.workspace = true
 
@@ -78,17 +78,17 @@ cumulus-relay-chain-interface.workspace = true
 [features]
 default = []
 runtime-benchmarks = [
-	"cumulus-primitives-core/runtime-benchmarks",
-	"frame-benchmarking-cli/runtime-benchmarks",
-	"frame-benchmarking/runtime-benchmarks",
-	"parachain-template-runtime/runtime-benchmarks",
-	"polkadot-cli/runtime-benchmarks",
-	"polkadot-primitives/runtime-benchmarks",
-	"sc-service/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
+    "cumulus-primitives-core/runtime-benchmarks",
+    "frame-benchmarking-cli/runtime-benchmarks",
+    "frame-benchmarking/runtime-benchmarks",
+    "parachain-template-runtime/runtime-benchmarks",
+    "polkadot-cli/runtime-benchmarks",
+    "polkadot-primitives/runtime-benchmarks",
+    "sc-service/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-	"parachain-template-runtime/try-runtime",
-	"polkadot-cli/try-runtime",
-	"sp-runtime/try-runtime",
+    "parachain-template-runtime/try-runtime",
+    "polkadot-cli/try-runtime",
+    "sp-runtime/try-runtime",
 ]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -38,11 +38,6 @@ pub enum Subcommand {
     /// The pallet benchmarking moved to the `pallet` sub-command.
     #[command(subcommand)]
     Benchmark(frame_benchmarking_cli::BenchmarkCmd),
-
-    /// Try-runtime has migrated to a standalone
-    /// [CLI](<https://github.com/paritytech/try-runtime-cli>). The subcommand exists as a stub and
-    /// deprecation notice. It will be removed entirely some time after January 2024.
-    TryRuntime,
 }
 
 const AFTER_HELP_EXAMPLE: &str = color_print::cstr!(

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -10,7 +10,6 @@ use sc_cli::{
     NetworkParams, Result, SharedParams, SubstrateCli,
 };
 use sc_service::config::{BasePath, PrometheusConfig};
-use sp_runtime::traits::AccountIdConversion;
 
 use crate::{
     chain_spec,
@@ -117,157 +116,162 @@ pub fn run() -> Result<()> {
     let cli = Cli::from_args();
 
     match &cli.subcommand {
-		Some(Subcommand::BuildSpec(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
-		},
-		Some(Subcommand::CheckBlock(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, components.import_queue))
-			})
-		},
-		Some(Subcommand::ExportBlocks(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, config.database))
-			})
-		},
-		Some(Subcommand::ExportState(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, config.chain_spec))
-			})
-		},
-		Some(Subcommand::ImportBlocks(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, components.import_queue))
-			})
-		},
-		Some(Subcommand::Revert(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, components.backend, None))
-			})
-		},
-		Some(Subcommand::PurgeChain(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
+        Some(Subcommand::BuildSpec(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
+        }
+        Some(Subcommand::CheckBlock(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, components.import_queue))
+            })
+        }
+        Some(Subcommand::ExportBlocks(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, config.database))
+            })
+        }
+        Some(Subcommand::ExportState(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, config.chain_spec))
+            })
+        }
+        Some(Subcommand::ImportBlocks(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, components.import_queue))
+            })
+        }
+        Some(Subcommand::Revert(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, components.backend, None))
+            })
+        }
+        Some(Subcommand::PurgeChain(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
 
-			runner.sync_run(|config| {
-				let polkadot_cli = RelayChainCli::new(
-					&config,
-					[RelayChainCli::executable_name()].iter().chain(cli.relay_chain_args.iter()),
-				);
+            runner.sync_run(|config| {
+                let polkadot_cli = RelayChainCli::new(
+                    &config,
+                    [RelayChainCli::executable_name()]
+                        .iter()
+                        .chain(cli.relay_chain_args.iter()),
+                );
 
-				let polkadot_config = SubstrateCli::create_configuration(
-					&polkadot_cli,
-					&polkadot_cli,
-					config.tokio_handle.clone(),
-				)
-				.map_err(|err| format!("Relay chain argument error: {}", err))?;
+                let polkadot_config = SubstrateCli::create_configuration(
+                    &polkadot_cli,
+                    &polkadot_cli,
+                    config.tokio_handle.clone(),
+                )
+                .map_err(|err| format!("Relay chain argument error: {}", err))?;
 
-				cmd.run(config, polkadot_config)
-			})
-		},
-		Some(Subcommand::ExportGenesisHead(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|config| {
-				let partials = new_partial(&config)?;
+                cmd.run(config, polkadot_config)
+            })
+        }
+        Some(Subcommand::ExportGenesisHead(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.sync_run(|config| {
+                let partials = new_partial(&config)?;
 
-				cmd.run(partials.client)
-			})
-		},
-		Some(Subcommand::ExportGenesisWasm(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|_config| {
-				let spec = cli.load_spec(&cmd.shared_params.chain.clone().unwrap_or_default())?;
-				cmd.run(&*spec)
-			})
-		},
-		Some(Subcommand::Benchmark(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			// Switch on the concrete benchmark sub-command-
-			match cmd {
-				BenchmarkCmd::Pallet(cmd) =>
-					if cfg!(feature = "runtime-benchmarks") {
-						runner.sync_run(|config| cmd.run::<sp_runtime::traits::HashingFor<Block>, ReclaimHostFunctions>(config))
-					} else {
-						Err("Benchmarking wasn't enabled when building the node. \
+                cmd.run(partials.client)
+            })
+        }
+        Some(Subcommand::ExportGenesisWasm(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.sync_run(|_config| {
+                let spec = cli.load_spec(&cmd.shared_params.chain.clone().unwrap_or_default())?;
+                cmd.run(&*spec)
+            })
+        }
+        Some(Subcommand::Benchmark(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            // Switch on the concrete benchmark sub-command-
+            match cmd {
+                BenchmarkCmd::Pallet(cmd) => {
+                    if cfg!(feature = "runtime-benchmarks") {
+                        runner.sync_run(|config| cmd.run_with_spec::<sp_runtime::traits::HashingFor<Block>, ReclaimHostFunctions>(Some(config.chain_spec)))
+                    } else {
+                        Err("Benchmarking wasn't enabled when building the node. \
 					You can enable it with `--features runtime-benchmarks`."
-							.into())
-					},
-				BenchmarkCmd::Block(cmd) => runner.sync_run(|config| {
-					let partials = new_partial(&config)?;
-					cmd.run(partials.client)
-				}),
-				#[cfg(not(feature = "runtime-benchmarks"))]
-				BenchmarkCmd::Storage(_) =>
-					Err(sc_cli::Error::Input(
-						"Compile with --features=runtime-benchmarks \
+                            .into())
+                    }
+                }
+                BenchmarkCmd::Block(cmd) => runner.sync_run(|config| {
+                    let partials = new_partial(&config)?;
+                    cmd.run(partials.client)
+                }),
+                #[cfg(not(feature = "runtime-benchmarks"))]
+                BenchmarkCmd::Storage(_) => Err(sc_cli::Error::Input(
+                    "Compile with --features=runtime-benchmarks \
 						to enable storage benchmarks."
-							.into(),
-					)),
-				#[cfg(feature = "runtime-benchmarks")]
-				BenchmarkCmd::Storage(cmd) => runner.sync_run(|config| {
-					let partials = new_partial(&config)?;
-					let db = partials.backend.expose_db();
-					let storage = partials.backend.expose_storage();
-					cmd.run(config, partials.client.clone(), db, storage)
-				}),
-				BenchmarkCmd::Machine(cmd) =>
-					runner.sync_run(|config| cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone())),
-				// NOTE: this allows the Client to leniently implement
-				// new benchmark commands without requiring a companion MR.
-				#[allow(unreachable_patterns)]
-				_ => Err("Benchmarking sub-command unsupported".into()),
-			}
-		},
-		Some(Subcommand::TryRuntime) => Err("The `try-runtime` subcommand has been migrated to a standalone CLI (https://github.com/paritytech/try-runtime-cli). It is no longer being maintained here and will be removed entirely some time after January 2024. Please remove this subcommand from your runtime and use the standalone CLI.".into()),
-		None => {
-			let runner = cli.create_runner(&cli.run.normalize())?;
-			let collator_options = cli.run.collator_options();
+                        .into(),
+                )),
+                #[cfg(feature = "runtime-benchmarks")]
+                BenchmarkCmd::Storage(cmd) => runner.sync_run(|config| {
+                    let partials = new_partial(&config)?;
+                    let db = partials.backend.expose_db();
+                    let storage = partials.backend.expose_storage();
+                    cmd.run(config, partials.client.clone(), db, storage)
+                }),
+                BenchmarkCmd::Machine(cmd) => {
+                    runner.sync_run(|config| cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()))
+                }
+                // NOTE: this allows the Client to leniently implement
+                // new benchmark commands without requiring a companion MR.
+                #[allow(unreachable_patterns)]
+                _ => Err("Benchmarking sub-command unsupported".into()),
+            }
+        }
+        None => {
+            let runner = cli.create_runner(&cli.run.normalize())?;
+            let collator_options = cli.run.collator_options();
 
-			runner.run_node_until_exit(|config| async move {
-				let hwbench = (!cli.no_hardware_benchmarks)
-					.then_some(config.database.path().map(|database_path| {
-						let _ = std::fs::create_dir_all(database_path);
-						sc_sysinfo::gather_hwbench(Some(database_path))
-					}))
-					.flatten();
+            runner.run_node_until_exit(|config| async move {
+                let hwbench = (!cli.no_hardware_benchmarks)
+                    .then_some(config.database.path().map(|database_path| {
+                        let _ = std::fs::create_dir_all(database_path);
+                        sc_sysinfo::gather_hwbench(Some(database_path))
+                    }))
+                    .flatten();
 
-				let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
-					.map(|e| e.para_id)
-					.ok_or("Could not find parachain ID in chain-spec.")?;
+                let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
+                    .map(|e| e.para_id)
+                    .ok_or("Could not find parachain ID in chain-spec.")?;
 
-				let polkadot_cli = RelayChainCli::new(
-					&config,
-					[RelayChainCli::executable_name()].iter().chain(cli.relay_chain_args.iter()),
-				);
+                let polkadot_cli = RelayChainCli::new(
+                    &config,
+                    [RelayChainCli::executable_name()]
+                        .iter()
+                        .chain(cli.relay_chain_args.iter()),
+                );
 
-				let id = ParaId::from(para_id);
+                let id = ParaId::from(para_id);
 
-				let parachain_account =
-					AccountIdConversion::<polkadot_primitives::AccountId>::into_account_truncating(
-						&id,
-					);
+                let tokio_handle = config.tokio_handle.clone();
+                let polkadot_config =
+                    SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
+                        .map_err(|err| format!("Relay chain argument error: {}", err))?;
 
-				let tokio_handle = config.tokio_handle.clone();
-				let polkadot_config =
-					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
-						.map_err(|err| format!("Relay chain argument error: {}", err))?;
+                info!(
+                    "Is collating: {}",
+                    if config.role.is_authority() {
+                        "yes"
+                    } else {
+                        "no"
+                    }
+                );
 
-				info!("Parachain Account: {parachain_account}");
-				info!("Is collating: {}", if config.role.is_authority() { "yes" } else { "no" });
-
-				crate::service::start_parachain_node(
-					config,
-					polkadot_config,
-					collator_options,
-					id,
-					hwbench,
-				)
-				.await
-				.map(|r| r.0)
-				.map_err(Into::into)
-			})
-		},
-	}
+                crate::service::start_parachain_node(
+                    config,
+                    polkadot_config,
+                    collator_options,
+                    id,
+                    hwbench,
+                )
+                .await
+                .map(|r| r.0)
+                .map_err(Into::into)
+            })
+        }
+    }
 }
 
 impl DefaultConfigurationValues for RelayChainCli {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -125,7 +125,7 @@ pub fn new_partial(config: &Configuration) -> Result<Service, sc_service::Error>
         config,
         telemetry.as_ref().map(|telemetry| telemetry.handle()),
         &task_manager,
-    )?;
+    );
 
     Ok(PartialComponents {
         backend,
@@ -139,11 +139,106 @@ pub fn new_partial(config: &Configuration) -> Result<Service, sc_service::Error>
     })
 }
 
+/// Build the import queue for the parachain runtime.
+fn build_import_queue(
+    client: Arc<ParachainClient>,
+    block_import: ParachainBlockImport,
+    config: &Configuration,
+    telemetry: Option<TelemetryHandle>,
+    task_manager: &TaskManager,
+) -> sc_consensus::DefaultImportQueue<Block> {
+    cumulus_client_consensus_aura::equivocation_import_queue::fully_verifying_import_queue::<
+        sp_consensus_aura::sr25519::AuthorityPair,
+        _,
+        _,
+        _,
+        _,
+    >(
+        client,
+        block_import,
+        move |_, _| async move {
+            let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+            Ok(timestamp)
+        },
+        &task_manager.spawn_essential_handle(),
+        config.prometheus_registry(),
+        telemetry,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn start_consensus(
+    client: Arc<ParachainClient>,
+    backend: Arc<ParachainBackend>,
+    block_import: ParachainBlockImport,
+    prometheus_registry: Option<&Registry>,
+    telemetry: Option<TelemetryHandle>,
+    task_manager: &TaskManager,
+    relay_chain_interface: Arc<dyn RelayChainInterface>,
+    transaction_pool: Arc<sc_transaction_pool::FullPool<Block, ParachainClient>>,
+    sync_oracle: Arc<SyncingService<Block>>,
+    keystore: KeystorePtr,
+    relay_chain_slot_duration: Duration,
+    para_id: ParaId,
+    collator_key: CollatorPair,
+    overseer_handle: OverseerHandle,
+    announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
+) -> Result<(), sc_service::Error> {
+    let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
+        task_manager.spawn_handle(),
+        client.clone(),
+        transaction_pool,
+        prometheus_registry,
+        telemetry.clone(),
+    );
+
+    let proposer = Proposer::new(proposer_factory);
+
+    let collator_service = CollatorService::new(
+        client.clone(),
+        Arc::new(task_manager.spawn_handle()),
+        announce_block,
+        client.clone(),
+    );
+
+    let params = AuraParams {
+        create_inherent_data_providers: move |_, ()| async move { Ok(()) },
+        block_import,
+        para_client: client.clone(),
+        para_backend: backend,
+        relay_client: relay_chain_interface,
+        code_hash_provider: move |block_hash| {
+            client
+                .code_at(block_hash)
+                .ok()
+                .map(|c| ValidationCode::from(c).hash())
+        },
+        sync_oracle,
+        keystore,
+        collator_key,
+        para_id,
+        overseer_handle,
+        relay_chain_slot_duration,
+        proposer,
+        collator_service,
+        authoring_duration: Duration::from_millis(2000),
+        reinitialize: false,
+    };
+
+    let fut =
+        aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _, _>(
+            params,
+        );
+    task_manager
+        .spawn_essential_handle()
+        .spawn("aura", None, fut);
+
+    Ok(())
+}
+
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
-///
-/// This is the actual implementation that is abstract over the executor and the runtime api.
 #[sc_tracing::logging::prefix_logs_with("Parachain")]
-async fn start_node_impl(
+pub async fn start_parachain_node(
     parachain_config: Configuration,
     polkadot_config: Configuration,
     collator_options: CollatorOptions,
@@ -154,7 +249,11 @@ async fn start_node_impl(
 
     let params = new_partial(&parachain_config)?;
     let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
-    let net_config = sc_network::config::FullNetworkConfiguration::new(&parachain_config.network);
+    let net_config = sc_network::config::FullNetworkConfiguration::<
+        _,
+        _,
+        sc_network::NetworkWorker<Block, Hash>,
+    >::new(&parachain_config.network);
 
     let client = params.client.clone();
     let backend = params.backend.clone();
@@ -176,6 +275,8 @@ async fn start_node_impl(
     let transaction_pool = params.transaction_pool.clone();
     let import_queue_service = params.import_queue.service();
 
+    // NOTE: because we use Aura here explicitly, we can use `CollatorSybilResistance::Resistant`
+    // when starting the network.
     let (network, system_rpc_tx, tx_handler_controller, start_network, sync_service) =
         build_network(BuildNetworkParams {
             parachain_config: &parachain_config,
@@ -203,7 +304,7 @@ async fn start_node_impl(
                 transaction_pool: Some(OffchainTransactionPoolFactory::new(
                     transaction_pool.clone(),
                 )),
-                network_provider: network.clone(),
+                network_provider: Arc::new(network.clone()),
                 is_validator: parachain_config.role.is_authority(),
                 enable_http_requests: false,
                 custom_extensions: move |_| vec![],
@@ -319,124 +420,4 @@ async fn start_node_impl(
     start_network.start_network();
 
     Ok((task_manager, client))
-}
-
-/// Build the import queue for the parachain runtime.
-fn build_import_queue(
-    client: Arc<ParachainClient>,
-    block_import: ParachainBlockImport,
-    config: &Configuration,
-    telemetry: Option<TelemetryHandle>,
-    task_manager: &TaskManager,
-) -> Result<sc_consensus::DefaultImportQueue<Block>, sc_service::Error> {
-    let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
-
-    Ok(
-        cumulus_client_consensus_aura::equivocation_import_queue::fully_verifying_import_queue::<
-            sp_consensus_aura::sr25519::AuthorityPair,
-            _,
-            _,
-            _,
-            _,
-        >(
-            client,
-            block_import,
-            move |_, _| async move {
-                let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-                Ok(timestamp)
-            },
-            slot_duration,
-            &task_manager.spawn_essential_handle(),
-            config.prometheus_registry(),
-            telemetry,
-        ),
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn start_consensus(
-    client: Arc<ParachainClient>,
-    backend: Arc<ParachainBackend>,
-    block_import: ParachainBlockImport,
-    prometheus_registry: Option<&Registry>,
-    telemetry: Option<TelemetryHandle>,
-    task_manager: &TaskManager,
-    relay_chain_interface: Arc<dyn RelayChainInterface>,
-    transaction_pool: Arc<sc_transaction_pool::FullPool<Block, ParachainClient>>,
-    sync_oracle: Arc<SyncingService<Block>>,
-    keystore: KeystorePtr,
-    relay_chain_slot_duration: Duration,
-    para_id: ParaId,
-    collator_key: CollatorPair,
-    overseer_handle: OverseerHandle,
-    announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
-) -> Result<(), sc_service::Error> {
-    let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
-        task_manager.spawn_handle(),
-        client.clone(),
-        transaction_pool,
-        prometheus_registry,
-        telemetry.clone(),
-    );
-
-    let proposer = Proposer::new(proposer_factory);
-
-    let collator_service = CollatorService::new(
-        client.clone(),
-        Arc::new(task_manager.spawn_handle()),
-        announce_block,
-        client.clone(),
-    );
-
-    let params = AuraParams {
-        create_inherent_data_providers: move |_, ()| async move { Ok(()) },
-        block_import,
-        para_client: client.clone(),
-        para_backend: backend,
-        relay_client: relay_chain_interface,
-        code_hash_provider: move |block_hash| {
-            client
-                .code_at(block_hash)
-                .ok()
-                .map(|c| ValidationCode::from(c).hash())
-        },
-        sync_oracle,
-        keystore,
-        collator_key,
-        para_id,
-        overseer_handle,
-        relay_chain_slot_duration,
-        proposer,
-        collator_service,
-        authoring_duration: Duration::from_millis(2000),
-        reinitialize: false,
-    };
-
-    let fut =
-        aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _, _>(
-            params,
-        );
-    task_manager
-        .spawn_essential_handle()
-        .spawn("aura", None, fut);
-
-    Ok(())
-}
-
-/// Start a parachain node.
-pub async fn start_parachain_node(
-    parachain_config: Configuration,
-    polkadot_config: Configuration,
-    collator_options: CollatorOptions,
-    para_id: ParaId,
-    hwbench: Option<sc_sysinfo::HwBench>,
-) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient>)> {
-    start_node_impl(
-        parachain_config,
-        polkadot_config,
-        collator_options,
-        para_id,
-        hwbench,
-    )
-    .await
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 substrate-wasm-builder.workspace = true
+docify.workspace = true
 
 [dependencies]
 codec.workspace = true
@@ -25,6 +26,7 @@ smallvec.workspace = true
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive.workspace = true
+frame-metadata-hash-extension.workspace = true
 frame-support.workspace = true
 frame-system.workspace = true
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -93,6 +95,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking/std",
 	"frame-system-rpc-runtime-api/std",
@@ -189,3 +192,16 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+
+# Enable the metadata hash generation.
+#
+# This is hidden behind a feature because it increases the compile time.
+# The wasm binary needs to be compiled twice, once to fetch the metadata,
+# generate the metadata hash and then a second time with the
+# `RUNTIME_METADATA_HASH` environment variable set for the `CheckMetadataHash`
+# extension.
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
+
+# A convenience feature for enabling things when doing a build
+# for an on-chain release.
+on-chain-release-build = ["metadata-hash"]

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,10 +1,14 @@
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+#[docify::export(template_enable_metadata_hash)]
 fn main() {
-    substrate_wasm_builder::WasmBuilder::new()
-        .with_current_project()
-        .export_heap_base()
-        .import_memory()
-        .build()
+    substrate_wasm_builder::WasmBuilder::init_with_defaults()
+        .enable_metadata_hash("UNIT", 12)
+        .build();
+}
+
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
+fn main() {
+    substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
 /// The wasm builder is deactivated when compiling

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -25,7 +25,7 @@
 
 // External crates imports
 use frame_support::{
-    genesis_builder_helper::{build_config, create_default_config},
+    genesis_builder_helper::{build_state, get_preset},
     traits::tokens::nonfungibles_v2::Inspect,
     weights::Weight,
 };
@@ -319,12 +319,16 @@ impl_runtime_apis! {
     }
 
     impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {
-        fn create_default_config() -> Vec<u8> {
-            create_default_config::<RuntimeGenesisConfig>()
+        fn build_state(config: Vec<u8>) -> sp_genesis_builder::Result {
+            build_state::<RuntimeGenesisConfig>(config)
         }
 
-        fn build_config(config: Vec<u8>) -> sp_genesis_builder::Result {
-            build_config::<RuntimeGenesisConfig>(config)
+        fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
+            get_preset::<RuntimeGenesisConfig>(id, |_| None)
+        }
+
+        fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
+            Default::default()
         }
     }
 }

--- a/runtime/src/benchmarks.rs
+++ b/runtime/src/benchmarks.rs
@@ -1,0 +1,37 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+//
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// For more information, please refer to <http://unlicense.org>
+
+frame_benchmarking::define_benchmarks!(
+    // Only benchmark the following pallets
+    [frame_system, SystemBench::<Runtime>]
+    [cumulus_pallet_parachain_system, ParachainSystem]
+    [pallet_timestamp, Timestamp]
+    [pallet_balances, Balances]
+    [pallet_sudo, Sudo]
+    [pallet_collator_selection, CollatorSelection]
+    [pallet_session, SessionBench::<Runtime>]
+    [cumulus_pallet_xcmp_queue, XcmpQueue]
+    [pallet_message_queue, MessageQueue]
+);

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -167,7 +167,7 @@ parameter_types! {
 
 impl pallet_transaction_payment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, ()>;
+    type OnChargeTransaction = pallet_transaction_payment::FungibleAdapter<Balances, ()>;
     type WeightToFee = WeightToFee;
     type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
     type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;

--- a/runtime/src/configs/xcm.rs
+++ b/runtime/src/configs/xcm.rs
@@ -58,6 +58,8 @@ parameter_types! {
     pub const RelayNetwork: Option<NetworkId> = None;
     pub const TokenLocation: Location = Location::here();
     pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
+    // For the real deployment, it is recommended to set `RelayNetwork` according to the relay chain
+    // and prepend `UniversalLocation` with `GlobalConsensus(RelayNetwork::get())`.
     pub UniversalLocation: InteriorLocation = Parachain(ParachainInfo::parachain_id().into()).into();
     pub TreasuryAccount: AccountId = TREASURY_PALLET_ID.into_account_truncating();
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -32,6 +32,8 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 pub mod apis;
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarks;
 mod configs;
 mod weights;
 
@@ -107,6 +109,7 @@ pub type SignedExtra = (
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
     cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
+    frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.
@@ -296,22 +299,6 @@ construct_runtime!(
         Assets: pallet_assets::<Instance1> = 42,
     }
 );
-
-#[cfg(feature = "runtime-benchmarks")]
-mod benches {
-    frame_benchmarking::define_benchmarks!(
-        // Only benchmark the following pallets
-        [frame_system, SystemBench::<Runtime>]
-        [cumulus_pallet_parachain_system, ParachainSystem]
-        [pallet_timestamp, Timestamp]
-        [pallet_balances, Balances]
-        [pallet_sudo, Sudo]
-        [pallet_collator_selection, CollatorSelection]
-        [pallet_session, SessionBench::<Runtime>]
-        [cumulus_pallet_xcmp_queue, XcmpQueue]
-        [pallet_message_queue, MessageQueue]
-    );
-}
 
 cumulus_pallet_parachain_system::register_validate_block! {
     Runtime = Runtime,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.75" # pinned to version used with polkadot release
+channel = "1.77" # pinned to version used with polkadot release
 components = ["rust-src", "rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
What I did to upgrade it.
First sync with` base-parachain `repository:
```
git remote add upstream https://github.com/r0gue-io/base-parachain.git
git fetch upstream
git merge upstream/main
```

Resolve locally the conflicts, and run `psvm -v "1.11.0”` for the specific assets pallets.
